### PR TITLE
feat: support multiple params in selected directives (close #89)

### DIFF
--- a/src/document/pintTransformer.ts
+++ b/src/document/pintTransformer.ts
@@ -382,15 +382,23 @@ export class PintTransformer {
 
                             replaceIndex += 1;
                         } else {
-                            const candidate = node.directiveParameters.substring(1, node.directiveParameters.length - 1).trim();
+                            let candidate = node.directiveParameters.substring(1, node.directiveParameters.length - 1).trim(),
+                                prefix = '$tVar = ',
+                                outputType = '=DIR';
+
+                            if (node.getArgCount() > 1) {
+                                candidate = '[' + candidate + ']';
+                                prefix = '$tArrVar = ';
+                                outputType = '=ADR';
+                            }
 
                             if (candidate.length == 0) { return; }
 
                             itemsInOutput += 1;
 
-                            results += '// ' + replaceIndex.toString() + '=DIR' + this.markerSuffix;
+                            results += '// ' + replaceIndex.toString() + outputType + this.markerSuffix;
                             results += "\n";
-                            results += '$tVar = ';
+                            results += prefix;
 
                             StringUtilities.breakByNewLine(candidate).forEach((cLine) => {
                                 results += cLine.trimLeft() + "\n";
@@ -650,6 +658,15 @@ export class PintTransformer {
             if (tResult.endsWith(';')) {
                 tResult = tResult.substring(0, tResult.length - 1).trimRight()
             }
+        } else if (type == 'ADR') {
+            tResult = tResult.trim().trimRight();
+            tResult = tResult.substring(10).trimLeft();
+            if (tResult.endsWith(';')) {
+                tResult = tResult.substring(0, tResult.length - 1).trimRight()
+            }
+
+            // Remove wrapping [ and ]
+            tResult = tResult.substring(1, tResult.length - 1);
         } else if (type == 'PHP') {
             tResult = result.trim().substring(5).trimLeft();
             tResult = tResult.trimRight();

--- a/src/document/printers/directivePrinter.ts
+++ b/src/document/printers/directivePrinter.ts
@@ -92,7 +92,8 @@ export class DirectivePrinter {
                     }
 
                     let tResult = params,
-                        removeLines = false;
+                        removeLines = false,
+                        trimShift = true;
 
                     const phpOptions = getPhpOptions();
                     if (params.startsWith('[') && params.endsWith(']') && directive.startPosition?.line != directive.endPosition?.line) {
@@ -179,15 +180,26 @@ export class DirectivePrinter {
                         tResult = tResult.substring(0, tResult.length - 14);
                     }
 
-                    if (
-                        directive
-                            .directiveName
-                            .toLowerCase()
-                            .match(
-                                /(^(include|section))|(^(each|extends)$)/
-                            )
-                    ) {
-                        tResult = tResult.substring(1, tResult.length - 2);
+                    if (directive.getArgCount() > 1) {
+                        let argTempResult = tResult;
+
+                        if (argTempResult.startsWith('[') && argTempResult.endsWith('];')) {
+                            argTempResult = tResult.substring(1, tResult.length - 2)
+                        }
+
+                        if (tResult.trimStart().startsWith('[') && tResult.trimEnd().endsWith('];')) {
+                            trimShift = false;
+                            argTempResult = "\n" + argTempResult.trimEnd();
+
+                            if (argTempResult.endsWith(',')) {
+                                argTempResult = argTempResult.substring(1, argTempResult.length - 1);
+                                argTempResult += "\n";
+                            }
+
+                            tResult = argTempResult;
+                        } else {
+                            tResult = argTempResult;
+                        }
                     }
 
                     if (GeneralSyntaxReflow.couldReflow(tResult)) {
@@ -203,8 +215,18 @@ export class DirectivePrinter {
                             tResult,
                             indentLevel,
                             true,
-                            options
-                        ) + ')';
+                            options,
+                            false,
+                            false,
+                            trimShift
+                        );
+
+                        if (! trimShift) {
+                            // We want to add some leading whitespace.
+                            paramContent += ' '.repeat(indentLevel);
+                        }
+
+                        paramContent += ')';
                     } else {
                         if (removeLines) {
                             tResult = removeContentLines(tResult);

--- a/src/document/printers/directivePrinter.ts
+++ b/src/document/printers/directivePrinter.ts
@@ -179,6 +179,13 @@ export class DirectivePrinter {
                         tResult = tResult.substring(0, tResult.length - 14);
                     }
 
+                    if (
+                        directive.directiveName.toLowerCase().startsWith('include') ||
+                        directive.directiveName.toLowerCase() === 'each'
+                    ) {
+                        tResult = tResult.substring(1, tResult.length - 2);
+                    }
+
                     if (GeneralSyntaxReflow.couldReflow(tResult)) {
                         tResult = GeneralSyntaxReflow.instance.reflow(tResult);
                     }

--- a/src/document/printers/directivePrinter.ts
+++ b/src/document/printers/directivePrinter.ts
@@ -174,7 +174,7 @@ export class DirectivePrinter {
                         }
                     }
 
-                    if (directive.directiveName.toLowerCase() == 'forelse') {
+                    if (directive.directiveName.match(/^for(each|else)$/)) {
                         tResult = tResult.substring(9);
                         tResult = tResult.substring(0, tResult.length - 14);
                     }

--- a/src/document/printers/directivePrinter.ts
+++ b/src/document/printers/directivePrinter.ts
@@ -180,8 +180,12 @@ export class DirectivePrinter {
                     }
 
                     if (
-                        directive.directiveName.toLowerCase().startsWith('include') ||
-                        directive.directiveName.toLowerCase() === 'each'
+                        directive
+                            .directiveName
+                            .toLowerCase()
+                            .match(
+                                /(^(include|section))|(^(each|extends)$)/
+                            )
                     ) {
                         tResult = tResult.substring(1, tResult.length - 2);
                     }
@@ -256,4 +260,3 @@ function removeContentLines(content: string): string {
 
     return newContent;
 }
-

--- a/src/document/printers/indentLevel.ts
+++ b/src/document/printers/indentLevel.ts
@@ -286,8 +286,22 @@ export class IndentLevel {
         return trimmedLines.join("\n");
     }
 
-    static shiftIndent(value: string, targetIndent: number, skipFirst: boolean = false, options: TransformOptions, reflowRelative: boolean = false, dedentLast: boolean = false): string {
-        const lines = StringUtilities.breakByNewLine(value.trim()),
+    static shiftIndent(
+        value: string,
+        targetIndent: number,
+        skipFirst: boolean = false,
+        options: TransformOptions,
+        reflowRelative: boolean = false,
+        dedentLast: boolean = false,
+        trimShift: boolean = true
+    ): string {
+        let breakValue = value;
+
+        if (trimShift) {
+            breakValue = value.trim();
+        }
+
+        const lines = StringUtilities.breakByNewLine(breakValue),
             reflowedLines: string[] = [];
 
         if (lines.length > 1) {

--- a/src/nodes/nodes.ts
+++ b/src/nodes/nodes.ts
@@ -417,6 +417,13 @@ export class DirectiveNode extends AbstractNode {
             return 'foreach (' + this.getInnerContent() + '):endforeach;';
         }
 
+        if (
+            this.directiveName.toLowerCase().startsWith('include') ||
+            this.directiveName.toLowerCase() === 'each'
+        ) {
+            return `[${this.getInnerContent()}];`;
+        }
+
         return this.directiveParameters;
     }
 

--- a/src/nodes/nodes.ts
+++ b/src/nodes/nodes.ts
@@ -418,8 +418,12 @@ export class DirectiveNode extends AbstractNode {
         }
 
         if (
-            this.directiveName.toLowerCase().startsWith('include') ||
-            this.directiveName.toLowerCase() === 'each'
+            this
+              .directiveName
+              .toLowerCase()
+              .match(
+                  /(^(include|section))|(^(each|extends)$)/
+              )
         ) {
             return `[${this.getInnerContent()}];`;
         }

--- a/src/nodes/nodes.ts
+++ b/src/nodes/nodes.ts
@@ -413,7 +413,7 @@ export class DirectiveNode extends AbstractNode {
     }
 
     getPhpContent() {
-        if (this.directiveName.toLowerCase() == 'forelse') {
+        if (this.directiveName.toLowerCase().match(/^for(each|else)$/)) {
             return 'foreach (' + this.getInnerContent() + '):endforeach;';
         }
 

--- a/src/nodes/nodes.ts
+++ b/src/nodes/nodes.ts
@@ -5,6 +5,7 @@ import { StringUtilities } from '../utilities/stringUtilities.js';
 import { BladeDocument } from '../document/bladeDocument.js';
 import { Offset } from './offset.js';
 import { BladeError } from '../errors/bladeError.js';
+import { ArgStringSplitter } from '../parser/argStringSplitter.js';
 
 function newRefId() {
     return StringUtilities.replaceAllInString(uuidv4(), '-', '_');
@@ -331,6 +332,7 @@ export class DirectiveNode extends AbstractNode {
 
     private cachedHasValidJson: boolean | null = null;
 
+    private cachedArgCount: number | null = null;
     private cachedHasValidPhp: boolean | null = null;
     private cachedPhpLastError: SyntaxError | null = null;
 
@@ -412,19 +414,31 @@ export class DirectiveNode extends AbstractNode {
         return immediateChildren;
     }
 
+    getArgCount() {
+        if (this.cachedArgCount == null) {
+            try {
+                const splitArgs = ArgStringSplitter.fromText(this.getInnerContent());
+                
+                this.cachedArgCount = splitArgs.length;
+            } catch (err) {
+                // Prevent any errors from crashing remaining process.
+                this.cachedArgCount = 1;
+            }
+        }
+
+        return this.cachedArgCount;
+    }
+
     getPhpContent() {
+        if (this.hasJsonParameters) {
+            return this.directiveParameters;
+        }
+
         if (this.directiveName.toLowerCase().match(/^for(each|else)$/)) {
             return 'foreach (' + this.getInnerContent() + '):endforeach;';
         }
 
-        if (
-            this
-              .directiveName
-              .toLowerCase()
-              .match(
-                  /(^(include|section))|(^(each|extends)$)/
-              )
-        ) {
+        if (this.getArgCount() > 1) {
             return `[${this.getInnerContent()}];`;
         }
 

--- a/src/parser/argStringSplitter.ts
+++ b/src/parser/argStringSplitter.ts
@@ -1,0 +1,142 @@
+import { isStartOfString } from './scanners/isStartOfString.js';
+import { scanToEndOfLogicGroup } from './scanners/scanToEndOfLogicGroup.js';
+import { skipToEndOfStringTraced } from './scanners/skipToEndOfString.js';
+import { StringIterator } from './stringIterator.js';
+
+export class ArgStringSplitter implements StringIterator {
+    private chars: string[] = [];
+    private value: string = '';
+    private cur: string | null = null;
+    private prev: string | null = null;
+    private next: string | null = null;
+    private currentIndex = 0;
+    private inputLen = 0;
+    private currentContent: string[] = [];
+    private returnStrings: string[] = [];
+
+
+    advance(count: number) {
+        for (let i = 0; i < count; i++) {
+            this.currentIndex++;
+            this.checkCurrentOffsets();
+        }
+    }
+    
+    encounteredFailure() {
+        return;
+    }
+    updateIndex(index: number): void {
+        this.currentIndex = index;
+    }
+    inputLength(): number {
+        return this.inputLen;
+    }
+    getCurrentIndex(): number {
+        return this.currentIndex;
+    }
+    incrementIndex(): void {
+        this.currentIndex += 1;
+    }
+    getCurrent(): string | null {
+        return this.cur;
+    }
+    getNext(): string | null {
+        return this.next;
+    }
+    getPrev(): string | null {
+        return this.prev;
+    }
+    checkCurrentOffsets(): void {
+        this.cur = this.chars[this.currentIndex];
+
+        this.prev = null;
+        this.next = null;
+
+        if (this.currentIndex > 0) {
+            this.prev = this.chars[this.currentIndex - 1];
+        }
+
+        if ((this.currentIndex + 1) < this.inputLen) {
+            this.next = this.chars[this.currentIndex + 1];
+        }
+    }
+    pushChar(value: string): void {
+        this.currentContent.push(value);
+    }
+    getChar(index: number): string {
+        return this.chars[index];
+    }
+    getSeedOffset(): number {
+        return 0;
+    }
+    getContentSubstring(from: number, length: number): string {
+        return this.value.substr(from, length);
+    }
+
+    static fromText(value: string): string[] {
+        const splitter = new ArgStringSplitter();
+
+        return splitter.split(value);
+    }
+
+    private pushCurrentContent() {
+        
+        const newContent = this.currentContent.join('');
+
+        if (newContent.trim().length > 0) {
+            this.returnStrings.push(newContent);
+        }
+    }
+
+    split(value: string): string[] {
+        this.value = value;
+        this.chars = value.split('');
+        this.returnStrings = [];
+        this.inputLen = this.chars.length;
+
+        for (this.currentIndex = 0; this.currentIndex < this.inputLen; this.currentIndex += 1) {
+            this.checkCurrentOffsets();
+
+            if (this.cur == '[') {
+                const arrayResult = scanToEndOfLogicGroup(this, '[', ']');
+                
+                this.returnStrings.push(arrayResult.content);
+                this.currentContent = [];
+                continue;
+            } else if (this.cur == '(') {
+                const groupResult = scanToEndOfLogicGroup(this, '(', ')');
+                
+                this.returnStrings.push(groupResult.content);
+                this.currentContent = [];
+                continue;
+            } else if (isStartOfString(this.cur)) {
+                const results = skipToEndOfStringTraced(this);
+
+                this.currentContent.push(this.cur as string);
+                this.currentContent = this.currentContent.concat(results.value.split(''));
+                this.currentContent.push(this.cur as string);
+                this.currentIndex = results.endedOn;
+
+                if (this.currentIndex == this.inputLen - 1) {
+                    this.pushCurrentContent();
+                    break;
+                }
+                continue;
+            }
+
+            if (this.cur == ',' || this.next == null) {
+                if (this.cur != ',') {
+                    this.currentContent.push(this.cur as string);
+                }
+
+                this.pushCurrentContent();
+                this.currentContent = [];
+                continue;
+            }
+
+            this.currentContent.push(this.cur as string);
+        }
+
+        return this.returnStrings;
+    }
+}

--- a/src/parser/scanners/scanToEndOfLogicGroup.ts
+++ b/src/parser/scanners/scanToEndOfLogicGroup.ts
@@ -6,7 +6,7 @@ import { skipToEndOfLine } from './skipToEndOfLine.js';
 import { skipToEndOfMultilineComment } from './skipToEndOfMultilineComment.js';
 import { skipToEndOfString } from './skipToEndOfString.js';
 
-export function scanToEndOfLogicGroup(iterator: StringIterator): LogicGroupScanResults {
+export function scanToEndOfLogicGroup(iterator: StringIterator, structureStart = '(', structureEnd = ')'): LogicGroupScanResults {
     const groupStartedOn = iterator.getCurrentIndex() + iterator.getSeedOffset(),
         recoveryIndex = iterator.getCurrentIndex();
     let groupEndsOn = 0,
@@ -41,12 +41,12 @@ export function scanToEndOfLogicGroup(iterator: StringIterator): LogicGroupScanR
             continue;
         }
 
-        if (iterator.getCurrent() == DocumentParser.LeftParen) {
+        if (iterator.getCurrent() == structureStart) {
             groupOpenCount += 1;
             continue;
         }
 
-        if (iterator.getCurrent() == DocumentParser.RightParen) {
+        if (iterator.getCurrent() == structureEnd) {
             if (groupOpenCount > 0) {
                 groupOpenCount -= 1;
                 continue;

--- a/src/test/formatter_can.test.ts
+++ b/src/test/formatter_can.test.ts
@@ -20,7 +20,7 @@ any
     "model",
 ])
 
-@can('update', $model)
+@can("update", $model)
     update
 @else
     any

--- a/src/test/formatter_directives.test.ts
+++ b/src/test/formatter_directives.test.ts
@@ -32,7 +32,7 @@ suite('Directives Formatting', () => {
             `@section("messages")
 <div class="alert success">
     <p><strong>Success!</strong></p>
-    @foreach ($success->all('<p>:message</p>') as $msg)
+    @foreach ($success->all("<p>:message</p>") as $msg)
         {{ $msg }}
     @endforeach
 </div>
@@ -53,7 +53,7 @@ suite('Directives Formatting', () => {
             `@section("messages")
 <div class="alert success">
     <p><strong>Success!</strong></p>
-    @foreach ($success->all('<p>:message</p>') as $msg)
+    @foreach ($success->all("<p>:message</p>") as $msg)
         {{ $msg }}
     @endforeach
 </div>
@@ -176,7 +176,7 @@ asdf
                 {!! $something_here !!}
                 @endcan
 `;
-        const out = `@can('create', App\\Models\\User::class)
+        const out = `@can("create", App\\Models\\User::class)
     {!! $something_here !!}
 @endcan
 `;

--- a/src/test/formatter_forelse.test.ts
+++ b/src/test/formatter_forelse.test.ts
@@ -2,6 +2,21 @@ import assert from 'assert';
 import { formatBladeString } from '../formatting/prettier/utils.js';
 
 suite('Forelse Formatting', () => {
+    test('it formats foreach', async () => {
+        assert.strictEqual(
+            (await formatBladeString(`<div>
+        @foreach (   $users   as   $id   =>    $user    )
+<li>{{ $user->name }}</li>
+@endforeach
+            </div>`)).trim(),
+            `<div>
+    @foreach ($users as $id => $user)
+        <li>{{ $user->name }}</li>
+    @endforeach
+</div>`
+        );
+    });
+
     test('it indents forelse', async () => {
         assert.strictEqual(
             (await formatBladeString(`<div>

--- a/src/test/formatter_include.test.ts
+++ b/src/test/formatter_include.test.ts
@@ -1,0 +1,70 @@
+import assert from 'assert';
+import { formatBladeString } from '../formatting/prettier/utils.js';
+import { setupTestHooks } from './testUtils/formatting.js';
+
+suite('@include Formatting', () => {
+  setupTestHooks();
+
+  test('it formats simple @include directives', async () => {
+    assert.strictEqual(
+      (await formatBladeString('@include( "shared.errors"   )')).trim(),
+      '@include("shared.errors")',
+    );
+  });
+
+  test('it formats @include directives with view parameters', async () => {
+    assert.strictEqual(
+      (
+        await formatBladeString('@include( "view.name"   , [ "status"   =>"complete"   ]   )')
+      ).trim(),
+      '@include("view.name", ["status" => "complete"])',
+    );
+  });
+
+  test('it formats conditional @include directives', async () => {
+    assert.strictEqual(
+      (await formatBladeString('@includeWhen(  $boolean,  "view.name"  , [ "status"   =>"complete"   ]    )')).trim(),
+      '@includeWhen($boolean, "view.name", ["status" => "complete"])',
+    );
+
+    assert.strictEqual(
+      (await formatBladeString('@includeUnless(  $boolean,  "view.name"  , [ "status"   =>"complete"   ]    )')).trim(),
+      '@includeUnless($boolean, "view.name", ["status" => "complete"])',
+    );
+  });
+
+  test('it formats @each directives', async () => {
+    assert.strictEqual(
+      (await formatBladeString('@each("view.name",   $jobs , "job"   )')).trim(),
+      '@each("view.name", $jobs, "job")',
+    );
+  });
+
+  test('it formats @include directives with many view  parameters', async () => {
+    assert.strictEqual(
+      (
+        await formatBladeString('@include( "lorem.ipsum.dolor"   , ["sit"=>"amet",    "consectetur" => "adipiscing", "elit" => "sed", "do" => "eiusmod" ]   )')
+      ).trim(),
+      `@include(
+    "lorem.ipsum.dolor",
+    [
+        "sit" => "amet",
+        "consectetur" => "adipiscing",
+        "elit" => "sed",
+        "do" => "eiusmod",
+    ]
+)`,
+    );
+  });
+
+  test('it formats @include directives with view parameters', async () => {
+    // This test is only to demonstrate that arrays allow this to work on main.
+    // This is not actually valid Blade, and should be removed before merge.
+    assert.strictEqual(
+      (
+        await formatBladeString('@include([ "a.b"   , [ "c"   =>"d"   ]   ])')
+      ).trim(),
+      '@include(["a.b", ["c" => "d"]])',
+    );
+  });
+});

--- a/src/test/formatter_include.test.ts
+++ b/src/test/formatter_include.test.ts
@@ -40,6 +40,20 @@ suite('@include Formatting', () => {
     );
   });
 
+  test('it formats @section directives with multiple parameters', async () => {
+    assert.strictEqual(
+      (await formatBladeString('@section( "title" ,  "Page Title" )')).trim(),
+      '@section("title", "Page Title")',
+    );
+  });
+
+  test('it formats @extends directives with view parameters', async () => {
+    assert.strictEqual(
+      (await formatBladeString('@extends("layouts.app" ,  [ "view"   =>"data"   ] )')).trim(),
+      '@extends("layouts.app", ["view" => "data"])',
+    );
+  });
+
   test('it formats @include directives with many view  parameters', async () => {
     assert.strictEqual(
       (

--- a/src/test/formatter_pint_directives.test.ts
+++ b/src/test/formatter_pint_directives.test.ts
@@ -32,7 +32,7 @@ suite('Pint Transformer: Directives', () => {
             `@section('messages')
 <div class="alert success">
     <p><strong>Success!</strong></p>
-    @foreach ($success->all("<p>:message</p>") as $msg)
+    @foreach ($success->all('<p>:message</p>') as $msg)
         {{ $msg }}
     @endforeach
 </div>

--- a/src/test/formatter_pint_directives.test.ts
+++ b/src/test/formatter_pint_directives.test.ts
@@ -32,7 +32,7 @@ suite('Pint Transformer: Directives', () => {
             `@section('messages')
 <div class="alert success">
     <p><strong>Success!</strong></p>
-    @foreach ($success->all('<p>:message</p>') as $msg)
+    @foreach ($success->all("<p>:message</p>") as $msg)
         {{ $msg }}
     @endforeach
 </div>

--- a/src/test/formatter_templates.test.ts
+++ b/src/test/formatter_templates.test.ts
@@ -37,7 +37,7 @@ suite('General Template Formatting', () => {
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-        <title>@yield('title', 'Default Title')</title>
+        <title>@yield("title", "Default Title")</title>
 
         <!-- Styles -->
         <link href="{{ asset("css/app.css") }}" rel="stylesheet" />
@@ -75,7 +75,7 @@ suite('General Template Formatting', () => {
 @endsection`;
         const out = `@extends("layouts.master")
 
-@section('title', 'About Us')
+@section("title", "About Us")
 
 @section("content")
     <h1>About Us</h1>
@@ -111,7 +111,7 @@ suite('General Template Formatting', () => {
 @endsection`;
         const out = `@extends("layouts.master")
 
-@section('title', 'User List')
+@section("title", "User List")
 
 @section("content")
     <h1>User List</h1>
@@ -155,7 +155,7 @@ suite('General Template Formatting', () => {
 @endsection`
         const out = `@extends("layouts.master")
 
-@section('title', 'Contact Us')
+@section("title", "Contact Us")
 
 @section("content")
     <h1>Contact Us</h1>
@@ -203,7 +203,7 @@ suite('General Template Formatting', () => {
 @endsection`;
         const out = `@extends("layouts.master")
 
-@section('title', 'Product Categories')
+@section("title", "Product Categories")
 
 @section("content")
     <h1>Product Categories</h1>
@@ -249,7 +249,7 @@ suite('General Template Formatting', () => {
 
         const out = `@extends("layouts.master")
 
-@section('title', 'Dashboard')
+@section("title", "Dashboard")
 
 @section("content")
     <h1>Dashboard</h1>
@@ -296,7 +296,7 @@ suite('General Template Formatting', () => {
         @endsection`;
         const out = `@extends("layouts.master")
 
-@section('title', 'Dashboard')
+@section("title", "Dashboard")
 
 @section("content")
     <h1>Dashboard</h1>
@@ -339,7 +339,7 @@ suite('General Template Formatting', () => {
         @endsection`
         const out = `@extends("layouts.master")
 
-@section('title', 'Notification')
+@section("title", "Notification")
 
 @section("content")
     <h1>Notification</h1>


### PR DESCRIPTION
- Adds support for `@include` and `@each` w/ more that one param
- ditto for `@section` and `@extends`, which I realized also accept multiple params
- "while I was here", I also noticed that `@forelse` is fully supported, but `@foreach` was not, so I added a fix for that too

Notes:
- As I said in #89, I'm not familiar with the codebase, so I'm happy to make any requested changes if this fix is too hacky (or in the wrong place), or just hand off the change to someone w/ more experience here
- I have not confirmed, but I wonder if this technique may need to account for the `trailingComma` option. For example, if 