### PR TITLE
test: incorrect html formatting

### DIFF
--- a/src/formatting/prettier/utils.ts
+++ b/src/formatting/prettier/utils.ts
@@ -194,7 +194,7 @@ export async function formatAsJavaScript(text: string, transformOptions: Transfo
 function getPrettierPlugins() {
     let plugins: any[] = [];
 
-    if (htmlOptions.plugins) {
+    if (htmlOptions?.plugins) {
         plugins = htmlOptions.plugins;
     }
 

--- a/src/test/formatter_markup.test.ts
+++ b/src/test/formatter_markup.test.ts
@@ -1,0 +1,40 @@
+import assert from 'assert';
+import { formatBladeString, formatAsHtml } from '../formatting/prettier/utils.js';
+
+suite('General HTML Formatting', () => {
+    test('it should format short HTML snippets the same as the core formatter', async () => {
+        const template = `<a target='_blank' href='/arbitrary-path/to-a-file'>Lorem ipsum dolor sit amet, consectetur</a>`;
+        const out = `<a target="_blank" href="/arbitrary-path/to-a-file"
+  >Lorem ipsum dolor sit amet, consectetur</a
+>
+`;
+
+        assert.strictEqual(await formatAsHtml(template), out, 'The fixture should match the output of the HTML formatter.');
+        assert.strictEqual(await formatBladeString(template), out);
+    });
+
+    test('it should format long HTML snippets the same as the core formatter', async () => {
+        const template = `<ul>
+    <li><strong>Lorem ipsum dolor sit amet, consectetur</strong> adipiscing elit, <a href="https://subdomain.example.com/sed/do-eiusmod/" target="_blank">tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis</a>. Nostrud <a href="https://subdomain.example.com/exercitation/ullamco-laboris/" target="_blank">Nisi ut aliquip ex ea commodo</a>.</li>
+</ul>
+`;
+        const out = `<ul>
+  <li>
+    <strong>Lorem ipsum dolor sit amet, consectetur</strong> adipiscing elit,
+    <a href="https://subdomain.example.com/sed/do-eiusmod/" target="_blank"
+      >tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis</a
+    >. Nostrud
+    <a
+      href="https://subdomain.example.com/exercitation/ullamco-laboris/"
+      target="_blank"
+      >Nisi ut aliquip ex ea commodo</a
+    >.
+  </li>
+</ul>
+`;
+
+        assert.strictEqual(await formatAsHtml(template), out, 'The fixture should match the output of the HTML formatter.');
+        assert.strictEqual(await formatBladeString(template), out);
+    });
+});


### PR DESCRIPTION
This adds a test for a couple of cases where the plugin is formatting markup in a way that changes the layout. For example, some (all?) cases of things like `<a ...>foo</a>.` are being formatted as 
```html
<a ...>
  foo
</a>
.
```
Which – depending on CSS – changes the rendered content in the browser because of the added whitespace around `foo` and `.`

The two tests I added are both taken from (obfuscated) examples I came across while running this plugin on our codebase at work, so they're nominally real-world examples. 😆 I just added assertions to see if the blade plugin produced identical output to the core prettier HTML parser/formatter, and both are failing. 

As noted in #90, I'm new around here, so it's possible that this is a known issue, or is being done intentionally, but these surprised me so I thought I'd report them. Thank you!