### PR TITLE
Adjusts directive spacing internal rules

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,8 @@ npx prettier "resources/views/**/*.blade.php" \
   --blade-component-prefixes x \
   --blade-component-prefixes flux \
   --blade-directive-arg-spacing space \
+  --blade-directive-arg-spacing-overrides if \
+  --blade-directive-arg-spacing-overrides section=0 \
   --blade-echo-spacing tight
 ```
 
@@ -189,6 +191,7 @@ Install the Tailwind CSS plugin and include it in `plugins`:
 | `bladeDirectiveCase` | `choice` | `"preserve"` | `"preserve"`, `"canonical"`, `"lower"` |
 | `bladeDirectiveCaseMap` | `string` | `""` | JSON object string, e.g. `{"disk":"Disk"}` |
 | `bladeDirectiveArgSpacing` | `choice` | `"space"` | `"preserve"`, `"none"`, `"space"` |
+| `bladeDirectiveArgSpacingOverrides` | `string[]` | `["if", "elseif", "unless", "while", "for", "foreach", "forelse", "switch", "case"]` | tokens like `if`, `section=none`, `php=2`, `custom=preserve` |
 | `bladeDirectiveBlockStyle` | `choice` | `"preserve"` | `"preserve"`, `"inline-if-short"`, `"multiline"` |
 | `bladeBlankLinesAroundDirectives` | `choice` | `"preserve"` | `"preserve"`, `"always"` |
 | `bladeEchoSpacing` | `choice` | `"preserve"` | `"preserve"`, `"space"`, `"tight"` |
@@ -219,6 +222,33 @@ Install the Tailwind CSS plugin and include it in `plugins`:
 - `svg` keeps single-line `<svg>...</svg>` container intent when the source is inline.
 - `svg:*` keeps inline attribute and style intent for SVG namespace elements such as `<path>` and `<line>`.
 - Remove one or both entries to opt out of those SVG-specific inline layouts.
+
+### Directive Arg Spacing
+
+Directive argument spacing has one base rule plus optional per-directive overrides.
+
+- `bladeDirectiveArgSpacing` is the base rule.
+- `bladeDirectiveArgSpacingOverrides` is a `string[]` of `directive[=rule]` options.
+- Directive names, without a specified rule, default to `space`.
+- Directive names are case-insensitive and may be written with or without `@`.
+- Rules may be `"preserve"`, `"none"`, `"space"`, or a non-negative integer.
+- Providing `bladeDirectiveArgSpacingOverrides` replaces the built-in defaults (`if`, `elseif`, `unless`, `while`, `for`, `foreach`, `forelse`, `switch`, `case`).
+
+Example:
+
+```json
+{
+  "bladeDirectiveArgSpacing": "none",
+  "bladeDirectiveArgSpacingOverrides": ["if", "section=1", "php=2"]
+}
+```
+
+With that configuration:
+
+- `@if($x)` becomes `@if ($x)`
+- `@include ($view)` becomes `@include($view)`
+- `@section($name)` becomes `@section ($name)`
+- `@php($expr)` becomes `@php  ($expr)`
 
 ### `bladeBlankLinesAroundDirectives`
 
@@ -317,6 +347,7 @@ This plugin also respects standard Prettier options, including:
         "bladeSyntaxPlugins": ["statamic"],
         "bladeDirectiveCase": "preserve",
         "bladeDirectiveArgSpacing": "space",
+        "bladeDirectiveArgSpacingOverrides": ["if", "elseif", "unless", "while", "for", "foreach", "forelse", "switch", "case"],
         "bladeDirectiveBlockStyle": "preserve",
         "bladeBlankLinesAroundDirectives": "preserve",
         "bladeEchoSpacing": "space",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import type { Plugin, SupportOption } from "prettier";
 import { bladeParser } from "./parser.js";
 import { bladePrinter } from "./printer.js";
+import { DEFAULT_DIRECTIVE_ARG_SPACING_OVERRIDE_TOKENS } from "./print/blade-options.js";
 
 const languages: Plugin["languages"] = [
   {
@@ -123,6 +124,14 @@ const options: Record<string, SupportOption> = {
         description: "Print with one space, e.g. @if ($x).",
       },
     ],
+  },
+  bladeDirectiveArgSpacingOverrides: {
+    category: "Blade",
+    type: "string",
+    array: true,
+    default: [{ value: [...DEFAULT_DIRECTIVE_ARG_SPACING_OVERRIDE_TOKENS] }],
+    description:
+      "Directive spacing overrides in directive[=rule] form; bare directive names imply space.",
   },
   bladeDirectiveBlockStyle: {
     category: "Blade",

--- a/src/print/attribute-name.ts
+++ b/src/print/attribute-name.ts
@@ -9,9 +9,10 @@ import {
 } from "./utils.js";
 import {
   formatDirectiveNameToken,
-  getDirectiveArgSpacingMode,
   getEchoSpacingMode,
+  getDirectiveArgSpacingText,
   isBladeComponentTagName,
+  resolveDirectiveArgSpacingRule,
 } from "./blade-options.js";
 
 function getEchoDelimiters(part: AttributeNamePart): { open: string; close: string } | null {
@@ -76,20 +77,18 @@ function formatDirectivePart(part: AttributeNamePart, node: WrappedNode, options
   const spacing = beforeArgs.slice(trimmedName.length);
   const args = part.text.slice(argsStart);
   const formattedName = formatDirectiveNameToken(trimmedName, options);
-  const spacingMode = isComponentAttributeName(node, options)
-    ? "none"
-    : getDirectiveArgSpacingMode(options);
+  const spacingRule = resolveDirectiveArgSpacingRule(
+    trimmedName,
+    options,
+    isComponentAttributeName(node, options),
+  );
 
-  if (spacingMode === "preserve") {
+  if (spacingRule === "preserve") {
     return `${formattedName}${spacing}${args}`;
   }
 
   const normalizedArgs = args.trimStart();
-  if (spacingMode === "none") {
-    return `${formattedName}${normalizedArgs}`;
-  }
-
-  return `${formattedName} ${normalizedArgs}`;
+  return `${formattedName}${getDirectiveArgSpacingText("", spacingRule)}${normalizedArgs}`;
 }
 
 function formatAttributeNamePart(

--- a/src/print/blade-options.ts
+++ b/src/print/blade-options.ts
@@ -3,12 +3,17 @@ import { getCanonicalDirectiveName } from "../lexer/directives.js";
 
 export type DirectiveCaseMode = "preserve" | "canonical" | "lower";
 export type DirectiveArgSpacingMode = "preserve" | "none" | "space";
+export type DirectiveArgSpacingRule = DirectiveArgSpacingMode | number;
 export type DirectiveBlockStyle = "preserve" | "inline-if-short" | "multiline";
 export type BladeBlankLinesMode = "preserve" | "always";
 export type EchoSpacingMode = "preserve" | "space" | "tight";
 export type SlotClosingTagMode = "canonical" | "preserve";
 
 const directiveCaseMapCache = new WeakMap<object, Map<string, string>>();
+const directiveArgSpacingOverridesCache = new WeakMap<
+  object,
+  Map<string, DirectiveArgSpacingRule>
+>();
 const inlineIntentElementsCache = new WeakMap<object, Set<string>>();
 const bladeComponentPrefixesCache = new WeakMap<object, string[]>();
 
@@ -21,9 +26,35 @@ const DEFAULT_BLADE_COMPONENT_PREFIXES = [
   "livewire",
   "native",
 ] as const;
+export const DEFAULT_DIRECTIVE_ARG_SPACING_OVERRIDE_TOKENS = Object.freeze([
+  "if",
+  "elseif",
+  "unless",
+  "while",
+  "for",
+  "foreach",
+  "forelse",
+  "switch",
+  "case",
+] as const);
+export const DEFAULT_DIRECTIVE_ARG_SPACING_OVERRIDES = Object.freeze({
+  if: "space",
+  elseif: "space",
+  unless: "space",
+  while: "space",
+  for: "space",
+  foreach: "space",
+  forelse: "space",
+  switch: "space",
+  case: "space",
+} satisfies Record<string, DirectiveArgSpacingMode>);
 
 function normalizeDirectiveName(name: string): string {
   return name.startsWith("@") ? name.slice(1) : name;
+}
+
+function normalizeDirectiveLookupName(name: string): string {
+  return normalizeDirectiveName(name.trim()).toLowerCase();
 }
 
 function dedupStrings(items: string[]): string[] {
@@ -125,6 +156,116 @@ export function getDirectiveArgSpacingMode(options: Options): DirectiveArgSpacin
     return value;
   }
   return "space";
+}
+
+function parseDirectiveArgSpacingRule(value: unknown): DirectiveArgSpacingRule | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (/^\d+$/u.test(normalized)) {
+    return Number.parseInt(normalized, 10);
+  }
+  if (normalized === "preserve" || normalized === "none" || normalized === "space") {
+    return normalized;
+  }
+
+  return null;
+}
+
+function parseDirectiveArgSpacingOverrideToken(
+  token: string,
+): [string, DirectiveArgSpacingRule] | null {
+  const trimmed = token.trim();
+  if (!trimmed) return null;
+
+  const separatorIndex = trimmed.indexOf("=");
+  if (separatorIndex === -1) {
+    const key = normalizeDirectiveLookupName(trimmed);
+    return key ? [key, "space"] : null;
+  }
+
+  const key = normalizeDirectiveLookupName(trimmed.slice(0, separatorIndex));
+  const rule = parseDirectiveArgSpacingRule(trimmed.slice(separatorIndex + 1));
+  if (!key || rule === null) return null;
+  return [key, rule];
+}
+
+function parseDirectiveArgSpacingOverridesValue(
+  value: unknown,
+): Map<string, DirectiveArgSpacingRule> {
+  const out = new Map<string, DirectiveArgSpacingRule>();
+
+  if (!Array.isArray(value)) {
+    return out;
+  }
+
+  for (const item of value) {
+    if (typeof item !== "string") continue;
+    const parsed = parseDirectiveArgSpacingOverrideToken(item);
+    if (!parsed) continue;
+    const [key, rule] = parsed;
+    out.set(key, rule);
+  }
+
+  return out;
+}
+
+export function getDirectiveArgSpacingOverrides(
+  options: Options,
+): Map<string, DirectiveArgSpacingRule> {
+  const key = options as unknown as object;
+  const cached = directiveArgSpacingOverridesCache.get(key);
+  if (cached) return cached;
+
+  const rawValue = (options as Record<string, unknown>).bladeDirectiveArgSpacingOverrides;
+  const result =
+    rawValue === undefined || rawValue === null
+      ? parseDirectiveArgSpacingOverridesValue(DEFAULT_DIRECTIVE_ARG_SPACING_OVERRIDE_TOKENS)
+      : parseDirectiveArgSpacingOverridesValue(rawValue);
+
+  directiveArgSpacingOverridesCache.set(key, result);
+  return result;
+}
+
+export function getDirectiveArgSpacingText(
+  authoredSpacing: string,
+  rule: DirectiveArgSpacingRule,
+): string {
+  if (rule === "preserve") {
+    return authoredSpacing;
+  }
+
+  if (rule === "none") {
+    return "";
+  }
+
+  if (rule === "space") {
+    return " ";
+  }
+
+  return " ".repeat(rule);
+}
+
+export function resolveDirectiveArgSpacingRule(
+  directiveName: string,
+  options: Options,
+  inBladeComponentAttribute = false,
+): DirectiveArgSpacingRule {
+  if (inBladeComponentAttribute) {
+    return 0;
+  }
+
+  const normalized = normalizeDirectiveLookupName(directiveName);
+  if (normalized) {
+    const override = getDirectiveArgSpacingOverrides(options).get(normalized);
+    if (override !== undefined) {
+      return override;
+    }
+  }
+
+  return getDirectiveArgSpacingMode(options);
 }
 
 export function getDirectiveBlockStyle(options: Options): DirectiveBlockStyle {

--- a/src/print/directive-spacing-context.ts
+++ b/src/print/directive-spacing-context.ts
@@ -1,0 +1,66 @@
+import type { Options } from "prettier";
+import type { WrappedNode } from "../types.js";
+import { TokenType } from "../lexer/types.js";
+import { NodeKind } from "../tree/types.js";
+import {
+  isBladeComponentTagName,
+  resolveDirectiveArgSpacingRule,
+  type DirectiveArgSpacingRule,
+} from "./blade-options.js";
+
+export function getDirectiveName(node: WrappedNode): string | null {
+  const start = node.flat.tokenStart;
+  const end = start + node.flat.tokenCount;
+  const tokens = node.buildResult.tokens;
+
+  for (let i = start; i < end; i++) {
+    const token = tokens[i];
+    if (token.type !== TokenType.Directive) continue;
+
+    const raw = node.source.slice(token.start, token.end);
+    return raw.startsWith("@") ? raw.slice(1).toLowerCase() : raw.toLowerCase();
+  }
+
+  return null;
+}
+
+export function getDirectiveAttributeContextElement(node: WrappedNode): WrappedNode | null {
+  let current = node;
+  while (current.parent?.kind === NodeKind.DirectiveBlock) {
+    current = current.parent;
+  }
+
+  const parent = current.parent;
+  if (!parent || parent.kind !== NodeKind.Element) {
+    return null;
+  }
+
+  return current.end <= parent.openTagEndOffset ? parent : null;
+}
+
+export function isDirectiveInElementOpenTag(node: WrappedNode): boolean {
+  return getDirectiveAttributeContextElement(node) !== null;
+}
+
+export function isDirectiveInBladeComponentAttributeContext(
+  node: WrappedNode,
+  options: Options,
+): boolean {
+  const element = getDirectiveAttributeContextElement(node);
+  if (!element) {
+    return false;
+  }
+
+  return isBladeComponentTagName(element.fullName, options);
+}
+
+export function getEffectiveDirectiveArgSpacingRule(
+  node: WrappedNode,
+  options: Options,
+): DirectiveArgSpacingRule {
+  return resolveDirectiveArgSpacingRule(
+    getDirectiveName(node) ?? "",
+    options,
+    isDirectiveInBladeComponentAttributeContext(node, options),
+  );
+}

--- a/src/print/directive.ts
+++ b/src/print/directive.ts
@@ -6,10 +6,14 @@ import { TokenType } from "../lexer/types.js";
 import {
   formatDirectiveNameToken,
   getBladeBlankLinesMode,
-  getDirectiveArgSpacingMode,
+  getDirectiveArgSpacingText,
   getDirectiveBlockStyle,
-  isBladeComponentTagName,
 } from "./blade-options.js";
+import {
+  getDirectiveName,
+  getEffectiveDirectiveArgSpacingRule,
+  isDirectiveInElementOpenTag,
+} from "./directive-spacing-context.js";
 import { trimTrailingHorizontalWhitespace } from "../string-utils.js";
 import { isEchoLike, isTextLikeNode } from "../node-predicates.js";
 import {
@@ -100,7 +104,7 @@ function renderDirectiveTokens(node: WrappedNode, options: Options): string {
   const br = node.buildResult;
   const tc = node.flat.tokenCount;
   let result = "";
-  const argSpacingMode = getEffectiveDirectiveArgSpacingMode(node, options);
+  const argSpacingRule = getEffectiveDirectiveArgSpacingRule(node, options);
   const start = node.flat.tokenStart;
   let sawDirectiveToken = false;
   let sawArgsToken = false;
@@ -115,8 +119,8 @@ function renderDirectiveTokens(node: WrappedNode, options: Options): string {
     if (t.type === TokenType.Directive) {
       result += formatDirectiveNameToken(tokenText, options);
       sawDirectiveToken = true;
-      if (argSpacingMode === "space" && next?.type === TokenType.DirectiveArgs) {
-        result += " ";
+      if (next?.type === TokenType.DirectiveArgs) {
+        result += getDirectiveArgSpacingText("", argSpacingRule);
       }
       continue;
     }
@@ -130,11 +134,7 @@ function renderDirectiveTokens(node: WrappedNode, options: Options): string {
       prev?.type === TokenType.Directive &&
       next?.type === TokenType.DirectiveArgs
     ) {
-      if (argSpacingMode === "preserve") {
-        result += tokenText;
-      } else if (argSpacingMode === "space" && !result.endsWith(" ")) {
-        result += " ";
-      }
+      result += getDirectiveArgSpacingText(tokenText, argSpacingRule);
       continue;
     }
 
@@ -163,17 +163,6 @@ function renderDirectiveTokens(node: WrappedNode, options: Options): string {
   }
 
   return result;
-}
-
-function getEffectiveDirectiveArgSpacingMode(
-  node: WrappedNode,
-  options: Options,
-): ReturnType<typeof getDirectiveArgSpacingMode> {
-  if (isDirectiveInBladeComponentAttributeContext(node, options)) {
-    return "none";
-  }
-
-  return getDirectiveArgSpacingMode(options);
 }
 
 function hasUnterminatedDirectiveArgsAtEof(node: WrappedNode): boolean {
@@ -609,33 +598,6 @@ function isInlineDirectiveBlock(node: WrappedNode): boolean {
   return true;
 }
 
-function isDirectiveInElementOpenTag(directive: WrappedNode): boolean {
-  return getAttributeContextElement(directive) !== null;
-}
-
-function isDirectiveInBladeComponentAttributeContext(node: WrappedNode, options: Options): boolean {
-  const element = getAttributeContextElement(node);
-  if (!element) {
-    return false;
-  }
-
-  return isBladeComponentTagName(element.fullName, options);
-}
-
-function getAttributeContextElement(node: WrappedNode): WrappedNode | null {
-  let current = node;
-  while (current.parent?.kind === NodeKind.DirectiveBlock) {
-    current = current.parent;
-  }
-
-  const parent = current.parent;
-  if (!parent || parent.kind !== NodeKind.Element) {
-    return null;
-  }
-
-  return current.end <= parent.openTagEndOffset ? parent : null;
-}
-
 function getSourceBetween(prev: WrappedNode, next: WrappedNode): string {
   if (prev.source !== next.source) {
     return "";
@@ -758,13 +720,11 @@ function isBodyLayoutDirective(node: WrappedNode): boolean {
     return false;
   }
 
-  const directiveToken = findFirstToken(node, TokenType.Directive);
-  if (!directiveToken) {
+  const name = getDirectiveName(node);
+  if (name === null) {
     return false;
   }
 
-  const raw = node.source.slice(directiveToken.start, directiveToken.end);
-  const name = raw.startsWith("@") ? raw.slice(1).toLowerCase() : raw.toLowerCase();
   return BODY_BLANK_LINE_LAYOUT_DIRECTIVES.has(name);
 }
 
@@ -782,18 +742,4 @@ function isContainerLikeBodySibling(node: WrappedNode): boolean {
 
 function isComponentLikeElement(node: WrappedNode): boolean {
   return node.tagName.includes("-") || node.fullName.includes(":");
-}
-
-function findFirstToken(node: WrappedNode, type: TokenType) {
-  const start = node.flat.tokenStart;
-  const end = start + node.flat.tokenCount;
-  const tokens = node.buildResult.tokens;
-
-  for (let i = start; i < end; i++) {
-    if (tokens[i].type === type) {
-      return tokens[i];
-    }
-  }
-
-  return null;
 }

--- a/src/print/embed/php.ts
+++ b/src/print/embed/php.ts
@@ -16,11 +16,11 @@ import {
 import { resolveBladeSyntaxPlugins } from "../../plugins/runtime.js";
 import { NodeKind } from "../../tree/types.js";
 import { fullText } from "../utils.js";
+import { getEchoSpacingMode, getDirectiveArgSpacingText } from "../blade-options.js";
 import {
-  getDirectiveArgSpacingMode,
-  getEchoSpacingMode,
-  isBladeComponentTagName,
-} from "../blade-options.js";
+  getDirectiveName,
+  getEffectiveDirectiveArgSpacingRule,
+} from "../directive-spacing-context.js";
 import { resolvePhpPlugins } from "./php-plugin.js";
 
 type PhpFormattingMode = "off" | "safe" | "aggressive";
@@ -427,6 +427,7 @@ function getCompensatedDelegatedPhpPrintWidth(snippet: string, options: Options)
 }
 
 function shouldPreferInlineDirectiveArgs(
+  node: WrappedNode,
   directiveName: string,
   payload: string,
   options: Options,
@@ -436,7 +437,11 @@ function shouldPreferInlineDirectiveArgs(
   }
 
   const printWidth = getPrintWidth(options);
-  const preview = `@${directiveName} (${payload})`;
+  const spacing = getDirectiveArgSpacingText(
+    "",
+    getEffectiveDirectiveArgSpacingRule(node, options),
+  );
+  const preview = `@${directiveName}${spacing}(${payload})`;
   return preview.length <= printWidth;
 }
 
@@ -543,15 +548,6 @@ async function formatPhpSnippet(
     setCachedPhpFormatResult(cacheKey, null);
     return null;
   }
-}
-
-function getDirectiveName(node: WrappedNode): string | null {
-  const directiveToken = findFirstToken(node, TokenType.Directive);
-  if (!directiveToken) return null;
-
-  const raw = node.source.slice(directiveToken.start, directiveToken.end);
-  if (!raw.startsWith("@")) return null;
-  return raw.slice(1).toLowerCase();
 }
 
 function getDirectiveWrapperContext(node: WrappedNode): DirectivePhpWrapperContext {
@@ -671,7 +667,7 @@ function rebuildDirectiveWithFormattedArgs(
   const start = node.flat.tokenStart;
   const end = start + node.flat.tokenCount;
   const tokens = node.buildResult.tokens;
-  const argSpacingMode = getEffectiveDirectiveArgSpacingMode(node, options);
+  const argSpacingRule = getEffectiveDirectiveArgSpacingRule(node, options);
   let result = "";
   let sawDirectiveToken = false;
   let sawArgsToken = false;
@@ -685,8 +681,8 @@ function rebuildDirectiveWithFormattedArgs(
     if (token.type === TokenType.Directive) {
       result += tokenText;
       sawDirectiveToken = true;
-      if (argSpacingMode === "space" && next?.type === TokenType.DirectiveArgs) {
-        result += " ";
+      if (next?.type === TokenType.DirectiveArgs) {
+        result += getDirectiveArgSpacingText("", argSpacingRule);
       }
       continue;
     }
@@ -700,11 +696,7 @@ function rebuildDirectiveWithFormattedArgs(
       prev?.type === TokenType.Directive &&
       next?.type === TokenType.DirectiveArgs
     ) {
-      if (argSpacingMode === "preserve") {
-        result += tokenText;
-      } else if (argSpacingMode === "space" && !result.endsWith(" ")) {
-        result += " ";
-      }
+      result += getDirectiveArgSpacingText(tokenText, argSpacingRule);
       continue;
     }
 
@@ -719,47 +711,6 @@ function rebuildDirectiveWithFormattedArgs(
   }
 
   return sawDirectiveToken ? result : "";
-}
-
-function getEffectiveDirectiveArgSpacingMode(
-  node: WrappedNode,
-  options: Options,
-): ReturnType<typeof getDirectiveArgSpacingMode> {
-  if (!isDirectiveComponentAttribute(node, options)) {
-    return getDirectiveArgSpacingMode(options);
-  }
-
-  return "none";
-}
-
-function isDirectiveComponentAttribute(node: WrappedNode, options: Options): boolean {
-  if (node.kind !== NodeKind.Directive) {
-    return false;
-  }
-
-  const parent = getAttributeContextElement(node);
-  if (!parent) {
-    return false;
-  }
-
-  if (!isBladeComponentTagName(parent.fullName, options)) {
-    return false;
-  }
-  return true;
-}
-
-function getAttributeContextElement(node: WrappedNode): WrappedNode | null {
-  let current = node;
-  while (current.parent?.kind === NodeKind.DirectiveBlock) {
-    current = current.parent;
-  }
-
-  const parent = current.parent;
-  if (!parent || parent.kind !== NodeKind.Element) {
-    return null;
-  }
-
-  return current.end <= parent.openTagEndOffset ? parent : null;
 }
 
 function getEchoDelimiters(node: WrappedNode): {
@@ -901,7 +852,7 @@ export async function formatDirectiveNodeArgs(
       : null;
     const finalPayload =
       collapsedInlinePayload &&
-      shouldPreferInlineDirectiveArgs(directiveName, collapsedInlinePayload, options)
+      shouldPreferInlineDirectiveArgs(node, directiveName, collapsedInlinePayload, options)
         ? collapsedInlinePayload
         : payload;
     const shouldPreserveWrappedMultilineArgs =

--- a/tests/cli/built-plugin-cli.test.ts
+++ b/tests/cli/built-plugin-cli.test.ts
@@ -6,12 +6,29 @@ import { fileURLToPath } from "node:url";
 import { beforeAll, describe, expect, it } from "vitest";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
-const prettierBinPath = join(repoRoot, "node_modules", "prettier", "bin", "prettier.cjs");
+const prettierBinPath = join(
+  repoRoot,
+  "node_modules",
+  "prettier",
+  "bin",
+  "prettier.cjs",
+);
 const builtPluginPath = join(repoRoot, "dist", "index.js");
-const tsupBinPath = join(repoRoot, "node_modules", "tsup", "dist", "cli-default.js");
+const tsupBinPath = join(
+  repoRoot,
+  "node_modules",
+  "tsup",
+  "dist",
+  "cli-default.js",
+);
 
 function assertSuccess(
-  result: { status: number | null; stdout: string; stderr: string; error?: Error },
+  result: {
+    status: number | null;
+    stdout: string;
+    stderr: string;
+    error?: Error;
+  },
   context: string,
 ): void {
   const diagnostics = [
@@ -40,15 +57,16 @@ beforeAll(() => {
     encoding: "utf8",
   });
 
-  assertSuccess(build, "expected tsup build to succeed before CLI integration tests");
+  assertSuccess(
+    build,
+    "expected tsup build to succeed before CLI integration tests",
+  );
 }, 30_000);
 
 describe("cli/built-plugin", () => {
-  it(
-    "loads Blade options from .prettierrc.json overrides using dist build",
-    () => {
-      const tempDir = mkdtempSync(join(tmpdir(), "blade-cli-config-"));
-      try {
+  it("loads Blade options from .prettierrc.json overrides using dist build", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "blade-cli-config-"));
+    try {
       const configPath = join(tempDir, ".prettierrc.json");
       writeFileSync(
         configPath,
@@ -62,6 +80,8 @@ describe("cli/built-plugin", () => {
                   parser: "blade",
                   bladePhpFormatting: "safe",
                   bladeEchoSpacing: "tight",
+                  bladeDirectiveArgSpacing: "none",
+                  bladeDirectiveArgSpacingOverrides: ["blaze=2"],
                 },
               },
             ],
@@ -72,44 +92,57 @@ describe("cli/built-plugin", () => {
       );
 
       const result = runPrettierCli(
-        ["--config", configPath, "--stdin-filepath", join(tempDir, "demo.blade.php")],
-        "{{$a+$b}}\n",
+        [
+          "--config",
+          configPath,
+          "--stdin-filepath",
+          join(tempDir, "demo.blade.php"),
+        ],
+        "{{$a+$b}}\n@blaze(a:1+2)\n",
         tempDir,
       );
 
-      assertSuccess(result, "expected prettier CLI with .prettierrc.json to succeed");
-      expect(result.stdout).toBe("{{$a + $b}}\n");
-      } finally {
-        rmSync(tempDir, { recursive: true, force: true });
-      }
-    },
-    20_000,
-  );
-
-  it(
-    "accepts kebab-case Blade option flags through prettier CLI with dist build",
-    () => {
-      const result = runPrettierCli(
-        [
-          "--plugin",
-          builtPluginPath,
-          "--plugin",
-          "@prettier/plugin-php",
-          "--parser",
-          "blade",
-          "--blade-php-formatting",
-          "safe",
-          "--blade-php-formatting-targets",
-          "echo",
-          "--blade-echo-spacing",
-          "tight",
-        ],
-        "{{$a+$b}}\n@blaze(a:1+2)\n",
+      assertSuccess(
+        result,
+        "expected prettier CLI with .prettierrc.json to succeed",
       );
+      expect(result.stdout).toBe("{{$a + $b}}\n@blaze  (a: 1 + 2)\n");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  }, 20_000);
 
-      assertSuccess(result, "expected prettier CLI with Blade option flags to succeed");
-      expect(result.stdout).toBe("{{$a + $b}}\n@blaze (a:1+2)\n");
-    },
-    20_000,
-  );
+  it("accepts kebab-case Blade option flags through prettier CLI with dist build", () => {
+    const result = runPrettierCli(
+      [
+        "--plugin",
+        builtPluginPath,
+        "--plugin",
+        "@prettier/plugin-php",
+        "--parser",
+        "blade",
+        "--blade-php-formatting",
+        "safe",
+        "--blade-php-formatting-targets",
+        "echo",
+        "--blade-echo-spacing",
+        "tight",
+        "--blade-directive-arg-spacing",
+        "none",
+        "--blade-directive-arg-spacing-overrides",
+        "if",
+        "--blade-directive-arg-spacing-overrides",
+        "blaze=2",
+      ],
+      "{{$a+$b}}\n@if($x)\n@endif\n@blaze(a:1+2)\n",
+    );
+
+    assertSuccess(
+      result,
+      "expected prettier CLI with Blade option flags to succeed",
+    );
+    expect(result.stdout).toBe(
+      "{{$a + $b}}\n@if ($x)\n@endif\n@blaze  (a:1+2)\n",
+    );
+  }, 20_000);
 });

--- a/tests/directives/issue-cases.test.ts
+++ b/tests/directives/issue-cases.test.ts
@@ -149,6 +149,16 @@ describe("directives/issue-cases", () => {
   it("#124: @class with nested array indents correctly without PHP formatting", async () => {
     const input = [
       "<div",
+      "  @class([",
+      "    'base-class',",
+      "    'active' => $isActive,",
+      "    'text-red' => $hasError,",
+      "  ])",
+      "></div>",
+      "",
+    ].join("\n");
+    const expected = [
+      "<div",
       "  @class ([",
       "    'base-class',",
       "    'active' => $isActive,",
@@ -157,7 +167,7 @@ describe("directives/issue-cases", () => {
       "></div>",
       "",
     ].join("\n");
-    await formatEqual(input, input, { bladePhpFormatting: "off" });
+    await formatEqual(input, expected, { bladePhpFormatting: "off" });
   });
 
   // Issue #123: conditionals in <input> attributes
@@ -167,11 +177,20 @@ describe("directives/issue-cases", () => {
       '  wire:model.defer="id"',
       '  type="text"',
       '  class="w-full border-gray-300 rounded-md"',
+      "  @unlessrole('admin') disabled @endunlessrole",
+      "/>",
+      "",
+    ].join("\n");
+    const expected = [
+      "<input",
+      '  wire:model.defer="id"',
+      '  type="text"',
+      '  class="w-full border-gray-300 rounded-md"',
       "  @unlessrole ('admin') disabled @endunlessrole",
       "/>",
       "",
     ].join("\n");
-    await formatEqual(input, input);
+    await formatEqual(input, expected);
   });
 
   it("#123: echo brace conditional in input attributes", async () => {
@@ -294,7 +313,7 @@ describe("directives/issue-cases", () => {
   // Issue #107: no progressive indentation in @section > @if
   it("#107: @section with nested @if does not drift on repeated formatting", async () => {
     const input = [
-      "@section ('head-mid')",
+      "@section('head-mid')",
       "  @if ($form->picture !== '')",
       '    <meta property="og:image" content="{{ $form->picture_url }}" />',
       "  @endif",
@@ -448,6 +467,16 @@ describe("pennant feature flag directives", () => {
     const input = [
       "<nav>",
       "  <ul>",
+      "    @feature('sidebar-v2')",
+      "      <li>New sidebar item</li>",
+      "    @endfeature",
+      "  </ul>",
+      "</nav>",
+      "",
+    ].join("\n");
+    const expected = [
+      "<nav>",
+      "  <ul>",
       "    @feature ('sidebar-v2')",
       "      <li>New sidebar item</li>",
       "    @endfeature",
@@ -455,6 +484,6 @@ describe("pennant feature flag directives", () => {
       "</nav>",
       "",
     ].join("\n");
-    await formatEqual(input, input);
+    await formatEqual(input, expected);
   });
 });

--- a/tests/directives/options.test.ts
+++ b/tests/directives/options.test.ts
@@ -24,29 +24,64 @@ describe("directives/options", () => {
   });
 
   it("supports bladeDirectiveArgSpacing preserve/none/space", async () => {
-    await formatEqual("@if($x)\n", "@if($x)\n", {
-      bladeDirectiveArgSpacing: "preserve",
-    });
+    await formatEqual(
+      "@section($x)\n@endsection\n",
+      "@section($x)\n@endsection\n",
+      {
+        bladeDirectiveArgSpacing: "preserve",
+      },
+    );
 
-    await formatEqual("@if ($x)\n", "@if($x)\n", {
-      bladeDirectiveArgSpacing: "none",
-    });
+    await formatEqual(
+      "@section ($x)\n@endsection\n",
+      "@section($x)\n@endsection\n",
+      {
+        bladeDirectiveArgSpacing: "none",
+      },
+    );
 
-    await formatEqual("@if($x)\n", "@if ($x)\n", {
-      bladeDirectiveArgSpacing: "space",
+    await formatEqual(
+      "@section($x)\n@endsection\n",
+      "@section ($x)\n@endsection\n",
+      {
+        bladeDirectiveArgSpacing: "space",
+      },
+    );
+  });
+
+  it("supports bladeDirectiveArgSpacingOverrides with rule and numeric values", async () => {
+    await formatEqual(
+      "@section($x)\n@endsection\n",
+      "@section ($x)\n@endsection\n",
+      {
+        bladeDirectiveArgSpacing: "none",
+        bladeDirectiveArgSpacingOverrides: ["section=space"],
+      },
+    );
+
+    await formatEqual("@if($x)\n@endif\n", "@if  ($x)\n@endif\n", {
+      bladeDirectiveArgSpacingOverrides: ["if=2"],
     });
   });
 
   it("supports bladeDirectiveBlockStyle preserve", async () => {
-    await formatEqual("@if($x) <span>x</span> @endif\n", "@if ($x)\n  <span>x</span>\n@endif\n", {
-      bladeDirectiveBlockStyle: "preserve",
-    });
+    await formatEqual(
+      "@if($x) <span>x</span> @endif\n",
+      "@if ($x)\n  <span>x</span>\n@endif\n",
+      {
+        bladeDirectiveBlockStyle: "preserve",
+      },
+    );
   });
 
   it("supports bladeDirectiveBlockStyle multiline", async () => {
-    await formatEqual("@if($x) <span>x</span> @endif\n", "@if ($x)\n  <span>x</span>\n@endif\n", {
-      bladeDirectiveBlockStyle: "multiline",
-    });
+    await formatEqual(
+      "@if($x) <span>x</span> @endif\n",
+      "@if ($x)\n  <span>x</span>\n@endif\n",
+      {
+        bladeDirectiveBlockStyle: "multiline",
+      },
+    );
   });
 
   it("supports bladeDirectiveBlockStyle inline-if-short", async () => {
@@ -59,15 +94,23 @@ describe("directives/options", () => {
     const compact = "@if($x)\n<p>a</p>\n@else\n<p>b</p>\n@endif\n";
     const withBlankLines = "@if($x)\n<p>a</p>\n\n@else\n<p>b</p>\n\n@endif\n";
 
-    await formatEqual(compact, "@if ($x)\n  <p>a</p>\n\n@else\n  <p>b</p>\n\n@endif\n", {
-      bladeDirectiveBlockStyle: "multiline",
-      bladeBlankLinesAroundDirectives: "always",
-    });
+    await formatEqual(
+      compact,
+      "@if ($x)\n  <p>a</p>\n\n@else\n  <p>b</p>\n\n@endif\n",
+      {
+        bladeDirectiveBlockStyle: "multiline",
+        bladeBlankLinesAroundDirectives: "always",
+      },
+    );
 
-    await formatEqual(withBlankLines, "@if ($x)\n  <p>a</p>\n\n@else\n  <p>b</p>\n\n@endif\n", {
-      bladeDirectiveBlockStyle: "multiline",
-      bladeBlankLinesAroundDirectives: "preserve",
-    });
+    await formatEqual(
+      withBlankLines,
+      "@if ($x)\n  <p>a</p>\n\n@else\n  <p>b</p>\n\n@endif\n",
+      {
+        bladeDirectiveBlockStyle: "multiline",
+        bladeBlankLinesAroundDirectives: "preserve",
+      },
+    );
   });
 
   it("does not treat blank lines inside a branch body as separator blank lines", async () => {
@@ -154,6 +197,7 @@ describe("directives/options", () => {
       {
         bladeDirectiveBlockStyle: "multiline",
         bladeBlankLinesAroundDirectives: "preserve",
+        bladeDirectiveArgSpacing: "space",
       },
     );
   });
@@ -183,6 +227,7 @@ describe("directives/options", () => {
       {
         bladeDirectiveBlockStyle: "multiline",
         bladeBlankLinesAroundDirectives: "preserve",
+        bladeDirectiveArgSpacing: "space",
       },
     );
   });
@@ -204,13 +249,21 @@ describe("directives/options", () => {
   it("applies bladeEchoSpacing to dynamic attribute values", async () => {
     const input = '<div wire:key="{{ $x }}" data-label="A{{ $y }}B"></div>\n';
 
-    await formatEqual(input, '<div wire:key="{{ $x }}" data-label="A{{ $y }}B"></div>\n', {
-      bladeEchoSpacing: "space",
-    });
+    await formatEqual(
+      input,
+      '<div wire:key="{{ $x }}" data-label="A{{ $y }}B"></div>\n',
+      {
+        bladeEchoSpacing: "space",
+      },
+    );
 
-    await formatEqual(input, '<div wire:key="{{$x}}" data-label="A{{$y}}B"></div>\n', {
-      bladeEchoSpacing: "tight",
-    });
+    await formatEqual(
+      input,
+      '<div wire:key="{{$x}}" data-label="A{{$y}}B"></div>\n',
+      {
+        bladeEchoSpacing: "tight",
+      },
+    );
   });
 
   it("supports bladeSlotClosingTag canonical/preserve", async () => {
@@ -232,9 +285,20 @@ describe("directives/options", () => {
   });
 
   it("normalizes trailing horizontal whitespace inside directive args", async () => {
-    const input = ["@varSet({", '  "logo":    ', "  ", '  "logo",   ', "})", ""].join("\n");
+    const input = [
+      "@varSet({",
+      '  "logo":    ',
+      "  ",
+      '  "logo",   ',
+      "})",
+      "",
+    ].join("\n");
 
-    const output = await formatWithPasses(input, {}, { passes: 3, assertIdempotent: true });
+    const output = await formatWithPasses(
+      input,
+      {},
+      { passes: 3, assertIdempotent: true },
+    );
 
     expect(output).toContain("@varSet ({");
     expect(output).not.toMatch(/[ \t]+$/mu);

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -99,6 +99,7 @@ function toHtmlReferenceOptions(options: prettier.Options): prettier.Options {
   delete htmlOptions.bladeDirectiveCase;
   delete htmlOptions.bladeDirectiveCaseMap;
   delete htmlOptions.bladeDirectiveArgSpacing;
+  delete htmlOptions.bladeDirectiveArgSpacingOverrides;
   delete htmlOptions.bladeDirectiveBlockStyle;
   delete htmlOptions.bladeBlankLinesAroundDirectives;
   delete htmlOptions.bladeEchoSpacing;

--- a/tests/options/directive-spacing-resolution.test.ts
+++ b/tests/options/directive-spacing-resolution.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { Options } from "prettier";
+import {
+  DEFAULT_DIRECTIVE_ARG_SPACING_OVERRIDES,
+  getDirectiveArgSpacingOverrides,
+  resolveDirectiveArgSpacingRule,
+} from "../../src/print/blade-options.js";
+
+describe("options/directive-spacing-resolution", () => {
+  it("seeds overrides with the built-in directive spacing defaults", () => {
+    const overrides = getDirectiveArgSpacingOverrides({} satisfies Options);
+
+    expect(Object.fromEntries(overrides)).toEqual(
+      DEFAULT_DIRECTIVE_ARG_SPACING_OVERRIDES,
+    );
+  });
+
+  it("parses array override tokens, normalizes directive names, and ignores invalid entries", () => {
+    const options = {
+      bladeDirectiveArgSpacingOverrides: [
+        "@IF",
+        " can = space ",
+        "AUTH=preserve",
+        "if=0",
+        "bad=-1",
+        "weird=1.5",
+        "=",
+      ],
+    } satisfies Options;
+
+    const overrides = getDirectiveArgSpacingOverrides(options);
+
+    expect(overrides.get("if")).toBe(0);
+    expect(overrides.get("can")).toBe("space");
+    expect(overrides.get("auth")).toBe("preserve");
+    expect(overrides.has("bad")).toBe(false);
+    expect(overrides.has("weird")).toBe(false);
+    expect(overrides.has("switch")).toBe(false);
+  });
+
+  it("resolves fallback spacing correctly when user tokens replace built-in defaults", () => {
+    const options = {
+      bladeDirectiveArgSpacing: "none",
+      bladeDirectiveArgSpacingOverrides: [
+        "@if=2",
+        "@can=space",
+        "section=preserve",
+        "bad=-1",
+        "float=1.5",
+      ],
+    } satisfies Options;
+
+    expect(resolveDirectiveArgSpacingRule("@if", options)).toBe(2);
+    expect(resolveDirectiveArgSpacingRule("@switch", options)).toBe("none");
+    expect(resolveDirectiveArgSpacingRule("@can", options)).toBe("space");
+    expect(resolveDirectiveArgSpacingRule("@section", options)).toBe(
+      "preserve",
+    );
+    expect(resolveDirectiveArgSpacingRule("@auth", options)).toBe("none");
+    expect(resolveDirectiveArgSpacingRule("@section", options, true)).toBe(0);
+  });
+});

--- a/tests/options/option-combinations.test.ts
+++ b/tests/options/option-combinations.test.ts
@@ -19,6 +19,10 @@ const INPUT = [
 
 const PHP_MODES = ["off", "safe", "aggressive"] as const;
 const DIRECTIVE_ARG_SPACING_MODES = ["none", "space"] as const;
+const DIRECTIVE_ARG_SPACING_OVERRIDE_MODES = [
+  { name: "default", value: undefined },
+  { name: "custom", value: ["if=0", "can", "php=2"] },
+] as const;
 const ECHO_SPACING_MODES = ["tight", "space"] as const;
 const END_OF_LINE_MODES = ["lf", "crlf"] as const;
 const INDENTATION_MODES = [
@@ -29,26 +33,39 @@ const INDENTATION_MODES = [
 function assertDirectiveArgSpacing(
   output: string,
   directiveArgSpacing: (typeof DIRECTIVE_ARG_SPACING_MODES)[number],
+  overrideMode: (typeof DIRECTIVE_ARG_SPACING_OVERRIDE_MODES)[number],
 ): void {
-  if (directiveArgSpacing === "none") {
+  if (overrideMode.name === "custom") {
     expect(output).toMatch(/@if\(/u);
-    expect(output).toMatch(/@can\(/u);
-    expect(output).toMatch(/@php\(/u);
     expect(output).not.toMatch(/@if \(/u);
-    expect(output).not.toMatch(/@can \(/u);
+    expect(output).toMatch(/@can \(/u);
+    expect(output).not.toMatch(/@can\(/u);
+    expect(output).toMatch(/@php  \(/u);
     expect(output).not.toMatch(/@php \(/u);
     return;
   }
 
   expect(output).toMatch(/@if \(/u);
+  expect(output).not.toMatch(/@if\(/u);
+
+  if (directiveArgSpacing === "none") {
+    expect(output).toMatch(/@can\(/u);
+    expect(output).toMatch(/@php\(/u);
+    expect(output).not.toMatch(/@can \(/u);
+    expect(output).not.toMatch(/@php \(/u);
+    return;
+  }
+
   expect(output).toMatch(/@can \(/u);
   expect(output).toMatch(/@php \(/u);
-  expect(output).not.toMatch(/@if\(/u);
   expect(output).not.toMatch(/@can\(/u);
   expect(output).not.toMatch(/@php\(/u);
 }
 
-function assertEchoSpacing(output: string, echoSpacing: (typeof ECHO_SPACING_MODES)[number]): void {
+function assertEchoSpacing(
+  output: string,
+  echoSpacing: (typeof ECHO_SPACING_MODES)[number],
+): void {
   if (echoSpacing === "tight") {
     expect(output).toMatch(/\{\{\$a(?:\s*\+\s*)\$b\}\}/u);
     expect(output).toMatch(/\{!!\$raw(?:\s*\+\s*)\$c!!\}/u);
@@ -63,7 +80,10 @@ function assertEchoSpacing(output: string, echoSpacing: (typeof ECHO_SPACING_MOD
   expect(output).toContain('wire:key="{{ $id }}"');
 }
 
-function assertEndOfLine(output: string, endOfLine: (typeof END_OF_LINE_MODES)[number]): void {
+function assertEndOfLine(
+  output: string,
+  endOfLine: (typeof END_OF_LINE_MODES)[number],
+): void {
   if (endOfLine === "lf") {
     expect(output.includes("\r\n")).toBe(false);
     return;
@@ -89,32 +109,45 @@ function assertIndentationMode(
 describe("options/option-combinations", () => {
   for (const phpMode of PHP_MODES) {
     for (const directiveArgSpacing of DIRECTIVE_ARG_SPACING_MODES) {
-      for (const echoSpacing of ECHO_SPACING_MODES) {
-        for (const endOfLine of END_OF_LINE_MODES) {
-          for (const indentationMode of INDENTATION_MODES) {
-            const caseName = [
-              `php=${phpMode}`,
-              `directiveArgSpacing=${directiveArgSpacing}`,
-              `echoSpacing=${echoSpacing}`,
-              `endOfLine=${endOfLine}`,
-              `indent=${indentationMode.name}`,
-            ].join(" | ");
+      for (const directiveArgSpacingOverrides of DIRECTIVE_ARG_SPACING_OVERRIDE_MODES) {
+        for (const echoSpacing of ECHO_SPACING_MODES) {
+          for (const endOfLine of END_OF_LINE_MODES) {
+            for (const indentationMode of INDENTATION_MODES) {
+              const caseName = [
+                `php=${phpMode}`,
+                `directiveArgSpacing=${directiveArgSpacing}`,
+                `directiveArgSpacingOverrides=${directiveArgSpacingOverrides.name}`,
+                `echoSpacing=${echoSpacing}`,
+                `endOfLine=${endOfLine}`,
+                `indent=${indentationMode.name}`,
+              ].join(" | ");
 
-            it(caseName, async () => {
-              const output = await format(INPUT, {
-                plugins: [bladePlugin, phpPlugin],
-                bladePhpFormatting: phpMode,
-                bladeDirectiveArgSpacing: directiveArgSpacing,
-                bladeEchoSpacing: echoSpacing,
-                endOfLine,
-                ...indentationMode.options,
+              it(caseName, async () => {
+                const output = await format(INPUT, {
+                  plugins: [bladePlugin, phpPlugin],
+                  bladePhpFormatting: phpMode,
+                  bladeDirectiveArgSpacing: directiveArgSpacing,
+                  ...(directiveArgSpacingOverrides.value === undefined
+                    ? {}
+                    : {
+                        bladeDirectiveArgSpacingOverrides:
+                          directiveArgSpacingOverrides.value,
+                      }),
+                  bladeEchoSpacing: echoSpacing,
+                  endOfLine,
+                  ...indentationMode.options,
+                });
+
+                assertDirectiveArgSpacing(
+                  output,
+                  directiveArgSpacing,
+                  directiveArgSpacingOverrides,
+                );
+                assertEchoSpacing(output, echoSpacing);
+                assertEndOfLine(output, endOfLine);
+                assertIndentationMode(output, indentationMode);
               });
-
-              assertDirectiveArgSpacing(output, directiveArgSpacing);
-              assertEchoSpacing(output, echoSpacing);
-              assertEndOfLine(output, endOfLine);
-              assertIndentationMode(output, indentationMode);
-            });
+            }
           }
         }
       }

--- a/tests/options/option-definitions.test.ts
+++ b/tests/options/option-definitions.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
-import bladePlugin, { options as declaredPluginOptions } from "../../src/index.js";
+import bladePlugin, {
+  options as declaredPluginOptions,
+} from "../../src/index.js";
 import * as phpPlugin from "@prettier/plugin-php";
+import { DEFAULT_DIRECTIVE_ARG_SPACING_OVERRIDE_TOKENS } from "../../src/print/blade-options.js";
 import { format, hasLoneLf } from "../helpers.js";
 
 async function formatWithPhp(input: string, options: Record<string, unknown>) {
@@ -46,13 +49,16 @@ const pluginOptionScenarios: Record<string, () => Promise<void>> = {
     expect(output).toContain("<?php $y=2+3; ?>");
   },
   bladeSyntaxPlugins: async () => {
-    const input = "@antlers\n<div>{{$x}}</div>\n@if($ready)\n@endantlers\n<div>{{$y}}</div>\n";
+    const input =
+      "@antlers\n<div>{{$x}}</div>\n@if($ready)\n@endantlers\n<div>{{$y}}</div>\n";
     const output = await format(input, {
       bladeEchoSpacing: "space",
       bladeSyntaxPlugins: ["statamic"],
     });
 
-    expect(output).toContain("@antlers\n<div>{{$x}}</div>\n@if($ready)\n@endantlers");
+    expect(output).toContain(
+      "@antlers\n<div>{{$x}}</div>\n@if($ready)\n@endantlers",
+    );
     expect(output).toContain("<div>{{ $y }}</div>");
 
     const sageInput = "@istrue($ready)<div>{{$title}}</div>@endistrue\n";
@@ -78,14 +84,26 @@ const pluginOptionScenarios: Record<string, () => Promise<void>> = {
     expect(canonical).toBe("@Disk ($value)\n");
   },
   bladeDirectiveArgSpacing: async () => {
-    const none = await format("@if ($x)\n@endif\n", {
+    const none = await format("@section ($x)\n@endsection\n", {
       bladeDirectiveArgSpacing: "none",
     });
-    const space = await format("@if($x)\n@endif\n", {
+    const space = await format("@section($x)\n@endsection\n", {
       bladeDirectiveArgSpacing: "space",
     });
-    expect(none).toContain("@if($x)");
-    expect(space).toContain("@if ($x)");
+    expect(none).toContain("@section($x)");
+    expect(space).toContain("@section ($x)");
+  },
+  bladeDirectiveArgSpacingOverrides: async () => {
+    const stringOverride = await format("@section('content')\n@endsection\n", {
+      bladeDirectiveArgSpacing: "none",
+      bladeDirectiveArgSpacingOverrides: ["section=space"],
+    });
+    const numericOverride = await format("@if($x)\n@endif\n", {
+      bladeDirectiveArgSpacingOverrides: ["if=2"],
+    });
+
+    expect(stringOverride).toContain("@section ('content')");
+    expect(numericOverride).toContain("@if  ($x)");
   },
   bladeDirectiveBlockStyle: async () => {
     const output = await format("@if($x)\n{{$y}}\n@endif\n", {
@@ -158,10 +176,14 @@ const pluginOptionScenarios: Record<string, () => Promise<void>> = {
     );
     expect(wrap).toContain("<svg>");
     expect(wrap).toContain("<path\n");
-    expect((rootOnly.match(/<path\b[\s\S]*?>/u)?.[0] ?? "").includes("\n")).toBe(true);
+    expect(
+      (rootOnly.match(/<path\b[\s\S]*?>/u)?.[0] ?? "").includes("\n"),
+    ).toBe(true);
     expect(rootOnly).toContain("<svg><path");
     expect(childrenOnly).toContain("<svg>\n");
-    expect((childrenOnly.match(/<path\b[\s\S]*?>/u)?.[0] ?? "").includes("\n")).toBe(false);
+    expect(
+      (childrenOnly.match(/<path\b[\s\S]*?>/u)?.[0] ?? "").includes("\n"),
+    ).toBe(false);
     expect(preserveParagraph.trimEnd()).toBe(
       '<p id="alpha" data-one="1" data-two="2" data-three="3" data-four="4" data-five="5" data-six="6" data-seven="7" data-eight="8">Hello {{ $name }} this is a long inline paragraph that should remain on one line.</p>',
     );
@@ -170,8 +192,10 @@ const pluginOptionScenarios: Record<string, () => Promise<void>> = {
   bladeComponentPrefixes: async () => {
     const dashInput = '<widget-card :title="$user->name??$fallback" />\n';
     const colonInput = '<widget:card :title="$user->name??$fallback" />\n';
-    const directiveDashInput = '<widget-card @if($enabled) disabled @endif />\n';
-    const directiveColonInput = '<widget:card @if($enabled) disabled @endif />\n';
+    const directiveDashInput =
+      "<widget-card @if($enabled) disabled @endif />\n";
+    const directiveColonInput =
+      "<widget:card @if($enabled) disabled @endif />\n";
 
     const defaultDashOutput = await formatWithPhp(dashInput, {
       bladePhpFormatting: "safe",
@@ -224,8 +248,12 @@ const pluginOptionScenarios: Record<string, () => Promise<void>> = {
       bladeKeepHeadAndBodyAtRoot: true,
     });
 
-    expect(defaultOutput).toContain("<html>\n  <head></head>\n  <body></body>\n</html>\n");
-    expect(rootOutput).toContain("<html>\n<head></head>\n<body></body>\n</html>\n");
+    expect(defaultOutput).toContain(
+      "<html>\n  <head></head>\n  <body></body>\n</html>\n",
+    );
+    expect(rootOutput).toContain(
+      "<html>\n<head></head>\n<body></body>\n</html>\n",
+    );
   },
 };
 
@@ -246,7 +274,8 @@ const delegatedCoreOptionScenarios: Record<string, () => Promise<void>> = {
     expect(noSemi).not.toContain("const x = 1;");
   },
   trailingComma: async () => {
-    const input = "<script>run({ alpha: 1, beta: 2, gamma: 3, longKey: 4 })</script>\n";
+    const input =
+      "<script>run({ alpha: 1, beta: 2, gamma: 3, longKey: 4 })</script>\n";
     const withTrailing = await format(input, {
       printWidth: 40,
       trailingComma: "all",
@@ -279,7 +308,8 @@ const delegatedCoreOptionScenarios: Record<string, () => Promise<void>> = {
     expect(consistent).toContain('"foo": 1, "bar-baz": 2');
   },
   jsxSingleQuote: async () => {
-    const input = '<script type="text/jsx">const node=<Comp title="hello" />;</script>\n';
+    const input =
+      '<script type="text/jsx">const node=<Comp title="hello" />;</script>\n';
     const single = await format(input, { jsxSingleQuote: true });
     const double = await format(input, { jsxSingleQuote: false });
     expect(single).toContain("title='hello'");
@@ -291,7 +321,9 @@ const delegatedCoreOptionScenarios: Record<string, () => Promise<void>> = {
     const narrow = await format(input, { printWidth: 40 });
     const wide = await format(input, { printWidth: 120 });
     expect(narrow).toContain("someFunction(\n");
-    expect(wide).toContain("const value = someFunction(alpha, beta, gamma, delta, epsilon, zeta);");
+    expect(wide).toContain(
+      "const value = someFunction(alpha, beta, gamma, delta, epsilon, zeta);",
+    );
   },
   tabWidth: async () => {
     const input = "<script>if (x) {\nconsole.log(1)\n}</script>\n";
@@ -336,7 +368,8 @@ const delegatedCoreOptionScenarios: Record<string, () => Promise<void>> = {
     expect(output).toContain('\n  data-c="3"\n');
   },
   bracketSameLine: async () => {
-    const input = '<div very_long_attribute_name="value_value_value_value_value_value"></div>\n';
+    const input =
+      '<div very_long_attribute_name="value_value_value_value_value_value"></div>\n';
     const output = await format(input, {
       printWidth: 40,
       bracketSameLine: true,
@@ -355,13 +388,26 @@ describe("options/option-definitions/blade-options", () => {
   it("declares the shipped defaults", () => {
     expect(declaredPluginOptions.bladePhpFormatting.default).toBe("safe");
     expect(declaredPluginOptions.bladeKeepHeadAndBodyAtRoot.default).toBe(true);
-    expect(declaredPluginOptions.bladeSyntaxPlugins.default).toEqual([{ value: ["statamic"] }]);
+    expect(declaredPluginOptions.bladeDirectiveArgSpacingOverrides.type).toBe(
+      "string",
+    );
+    expect(declaredPluginOptions.bladeDirectiveArgSpacingOverrides.array).toBe(
+      true,
+    );
+    expect(
+      declaredPluginOptions.bladeDirectiveArgSpacingOverrides.default,
+    ).toEqual([{ value: [...DEFAULT_DIRECTIVE_ARG_SPACING_OVERRIDE_TOKENS] }]);
+    expect(declaredPluginOptions.bladeSyntaxPlugins.default).toEqual([
+      { value: ["statamic"] },
+    ]);
     expect(declaredPluginOptions.bladeComponentPrefixes.default).toEqual([
       { value: ["x", "s", "statamic", "flux", "livewire", "native"] },
     ]);
   });
 
-  for (const [optionName, runScenario] of Object.entries(pluginOptionScenarios)) {
+  for (const [optionName, runScenario] of Object.entries(
+    pluginOptionScenarios,
+  )) {
     it(`covers ${optionName}`, async () => {
       await runScenario();
     });
@@ -369,7 +415,9 @@ describe("options/option-definitions/blade-options", () => {
 });
 
 describe("options/option-definitions/delegated-options", () => {
-  for (const [optionName, runScenario] of Object.entries(delegatedCoreOptionScenarios)) {
+  for (const [optionName, runScenario] of Object.entries(
+    delegatedCoreOptionScenarios,
+  )) {
     it(`passes ${optionName} through delegated formatters`, async () => {
       await runScenario();
     });

--- a/tests/options/option-pair-profiles.test.ts
+++ b/tests/options/option-pair-profiles.test.ts
@@ -55,11 +55,18 @@ const INPUT = `<!doctype html>
 const DOMAINS: Domain[] = [
   { key: "bladePhpFormatting", values: ["off", "safe"] },
   { key: "bladeDirectiveArgSpacing", values: ["none", "space"] },
+  {
+    key: "bladeDirectiveArgSpacingOverrides",
+    values: [undefined, ["if=0", "can", "php=2"]],
+  },
   { key: "bladeEchoSpacing", values: ["preserve", "space", "tight"] },
   { key: "bladeSlotClosingTag", values: ["canonical", "preserve"] },
   { key: "bladeInsertOptionalClosingTags", values: [false, true] },
   { key: "bladeKeepHeadAndBodyAtRoot", values: [false, true] },
-  { key: "bladeInlineIntentElements", values: [["p", "svg", "svg:*"], ["p"], []] },
+  {
+    key: "bladeInlineIntentElements",
+    values: [["p", "svg", "svg:*"], ["p"], []],
+  },
   { key: "singleQuote", values: [false, true] },
   { key: "printWidth", values: [60, 100] },
   { key: "useTabs", values: [false, true] },
@@ -104,7 +111,10 @@ function randomRow(domains: Domain[], rng: Rng): number[] {
 function rowToOptions(row: number[], domains: Domain[]): Options {
   const out: Record<string, unknown> = {};
   for (let i = 0; i < domains.length; i++) {
-    out[String(domains[i].key)] = domains[i].values[row[i]!];
+    const value = domains[i].values[row[i]!];
+    if (value !== undefined) {
+      out[String(domains[i].key)] = value;
+    }
   }
   return out as Options;
 }
@@ -165,7 +175,8 @@ function buildPairwiseRows(domains: Domain[]): Options[] {
 
 function summarizeOptions(options: Options): string {
   return DOMAINS.map(
-    (d) => `${String(d.key)}=${String((options as Record<string, unknown>)[d.key])}`,
+    (d) =>
+      `${String(d.key)}=${String((options as Record<string, unknown>)[d.key])}`,
   ).join(" | ");
 }
 

--- a/tests/php/options.test.ts
+++ b/tests/php/options.test.ts
@@ -46,6 +46,14 @@ describe("php/options", () => {
     });
   });
 
+  it("applies bladeDirectiveArgSpacingOverrides for @php directive args", async () => {
+    await formatEqual("@php($a+$b)\n", "@php  ($a + $b)\n", {
+      ...withPhp,
+      bladeDirectiveArgSpacing: "none",
+      bladeDirectiveArgSpacingOverrides: ["php=2"],
+    });
+  });
+
   it("passes singleQuote to php formatting", async () => {
     const input = '@blaze("alpha"."beta")\n';
 
@@ -121,13 +129,14 @@ describe("php/options", () => {
 
   it("does not introduce trailing commas in directive args", async () => {
     const input =
-      "@image ($item, 'large', ['class' => 'media size-full rounded-3xl object-cover object-center'])\n";
+      "@image($item, 'large', ['class' => 'media size-full rounded-3xl object-cover object-center'])\n";
 
     await formatEqual(
       input,
       "@image ($item, 'large', ['class' => 'media size-full rounded-3xl object-cover object-center'])\n",
       {
         ...withPhp,
+        bladeDirectiveArgSpacing: "space",
         printWidth: 120,
         singleQuote: true,
         trailingCommaPHP: true,
@@ -136,6 +145,7 @@ describe("php/options", () => {
 
     const multiline = await format(input, {
       ...withPhp,
+      bladeDirectiveArgSpacing: "space",
       printWidth: 40,
       singleQuote: true,
       trailingCommaPHP: true,
@@ -173,17 +183,25 @@ describe("php/options", () => {
   });
 
   it("supports bladePhpFormattingTargets=none", async () => {
-    await formatEqual("{{$a+$b}}\n@blaze(a:1+2)\n", "{{$a+$b}}\n@blaze (a:1+2)\n", {
-      ...withPhp,
-      bladePhpFormattingTargets: [],
-    });
+    await formatEqual(
+      "{{$a+$b}}\n@blaze(a:1+2)\n",
+      "{{$a+$b}}\n@blaze (a:1+2)\n",
+      {
+        ...withPhp,
+        bladePhpFormattingTargets: [],
+      },
+    );
   });
 
   it("supports bladePhpFormattingTargets=echo", async () => {
-    await formatEqual("{{$a+$b}}\n@blaze(a:1+2)\n", "{{ $a + $b }}\n@blaze (a:1+2)\n", {
-      ...withPhp,
-      bladePhpFormattingTargets: ["echo"],
-    });
+    await formatEqual(
+      "{{$a+$b}}\n@blaze(a:1+2)\n",
+      "{{ $a + $b }}\n@blaze (a:1+2)\n",
+      {
+        ...withPhp,
+        bladePhpFormattingTargets: ["echo"],
+      },
+    );
   });
 
   it("supports bladePhpFormattingTargets=directiveArgs", async () => {
@@ -210,8 +228,8 @@ describe("php/options", () => {
 
   it("respects bladeEchoSpacing=tight when php echo formatting is enabled", async () => {
     await formatEqual(
-      "{{$a+$b}}\n<div @if($x)wire:key=\"{{ $x->id }}\"@endif></div>\n",
-      "{{$a + $b}}\n<div @if ($x) wire:key=\"{{$x->id}}\"@endif></div>\n",
+      '{{$a+$b}}\n<div @if($x)wire:key="{{ $x->id }}"@endif></div>\n',
+      '{{$a + $b}}\n<div @if ($x) wire:key="{{$x->id}}"@endif></div>\n',
       {
         ...withPhp,
         bladeEchoSpacing: "tight",

--- a/tests/validation/conformance/__snapshots__/formatter-cases.test.ts.snap
+++ b/tests/validation/conformance/__snapshots__/formatter-cases.test.ts.snap
@@ -2063,9 +2063,9 @@ exports[`validation/conformance/formatter-cases > formats ignore__001 1`] = `
 {{-- 
                                                                             Just 
                                                 a comment --}}
-@if         ($true)
+@if ($true)
   <span>Hello</span>
-@elseif                     ($anotherValue)
+@elseif ($anotherValue)
   <div>
     <p>Hello world</p>
     <div>
@@ -2080,11 +2080,11 @@ exports[`validation/conformance/formatter-cases > formats ignore__001 1`] = `
 
 @endif
 
-@switch($i)
-  @case(1)
+@switch ($i)
+  @case (1)
     First case...
     @break
-  @case(2)
+  @case (2)
     Second case...
     @break
   @default
@@ -2092,16 +2092,16 @@ exports[`validation/conformance/formatter-cases > formats ignore__001 1`] = `
 
 @endswitch
 
-@unless($true)
+@unless ($true)
 
 @endunless
 
 @directive   ($test  + $that-$another   + $thing)
-@unless($true)
+@unless ($true)
   Hello
 @endunless
 
-@unless($true)
+@unless ($true)
   <p>World</p>
   <x-icon @class([$icon, 'pe-2'])>
     <div>
@@ -2262,11 +2262,11 @@ exports[`validation/conformance/formatter-cases > formats ignore__002 1`] = `
   <p>Test {{ $title }} test</p>
 @endif
 
-@switch($i)
-  @case(1)
+@switch ($i)
+  @case (1)
     First case...
     @break
-  @case(2)
+  @case (2)
     Second case...
     @break
   @default


### PR DESCRIPTION
Users would like a way to adjust the directive spacing for "control"-style directives, such as `@if`.

## The Problem

Chisel does not allow fine-tuned behavior changes for control-style directives.

## The Solution

This PR allows users to override the behavior of any directive. Instead of exposing the concept of a control directive and duplicating different settings, this PR allows the arbitrary override of any directive's spacing, with the control directives as the defaults.
