### PR TITLE
Improves component interpolation formatting

### DIFF
--- a/src/print/embed/php.ts
+++ b/src/print/embed/php.ts
@@ -16,7 +16,11 @@ import {
 import { resolveBladeSyntaxPlugins } from "../../plugins/runtime.js";
 import { NodeKind } from "../../tree/types.js";
 import { fullText } from "../utils.js";
-import { getEchoSpacingMode, getDirectiveArgSpacingText } from "../blade-options.js";
+import {
+  getEchoSpacingMode,
+  getDirectiveArgSpacingText,
+  isBladeComponentTagName,
+} from "../blade-options.js";
 import {
   getDirectiveName,
   getEffectiveDirectiveArgSpacingRule,
@@ -113,6 +117,18 @@ export function isPhpBlockNode(node: WrappedNode): boolean {
 }
 
 export const isEchoNode = isEchoLike;
+
+// Standalone echoes inside the open tag of a Blade component compile into a
+// double-quoted PHP string by Laravel's ComponentTagCompiler, so emitting
+// double quotes inside the echo would terminate that outer string. Force
+// single quotes when the parent element is a registered Blade component.
+function isInBladeComponentOpenTag(node: WrappedNode, options: Options): boolean {
+  const parent = node.parent;
+  if (!parent || parent.kind !== NodeKind.Element) return false;
+  if (parent.openTagEndOffset === 0) return false;
+  if (node.end > parent.openTagEndOffset) return false;
+  return isBladeComponentTagName(parent.fullName, options);
+}
 
 export function isDirectiveWithArgsNode(node: WrappedNode): boolean {
   if (node.kind !== NodeKind.Directive) return false;
@@ -450,6 +466,7 @@ function getPhpFormatCacheKey(
   mode: PhpFormattingMode,
   options: Options,
   trailingCommaPHPOverride?: boolean,
+  singleQuoteOverride?: boolean,
 ): string {
   const opts = options as Record<string, unknown>;
   const optionsKey = safeSerialize({
@@ -457,7 +474,7 @@ function getPhpFormatCacheKey(
     printWidth: opts.printWidth,
     tabWidth: opts.tabWidth,
     useTabs: opts.useTabs,
-    singleQuote: opts.singleQuote,
+    singleQuote: singleQuoteOverride === undefined ? opts.singleQuote : singleQuoteOverride,
     semi: opts.semi,
     trailingComma: opts.trailingComma,
     bracketSpacing: opts.bracketSpacing,
@@ -484,6 +501,7 @@ function createPhpFormatOptions(
   options: Options,
   plugins: unknown[],
   trailingCommaPHPOverride?: boolean,
+  singleQuoteOverride?: boolean,
 ): Options {
   const baseOptions = {
     ...(options as Record<string, unknown>),
@@ -515,6 +533,10 @@ function createPhpFormatOptions(
     baseOptions.trailingCommaPHP = trailingCommaPHPOverride;
   }
 
+  if (singleQuoteOverride !== undefined) {
+    baseOptions.singleQuote = singleQuoteOverride;
+  }
+
   return {
     ...baseOptions,
     parser: "php",
@@ -527,11 +549,18 @@ async function formatPhpSnippet(
   options: Options,
   mode: PhpFormattingMode,
   trailingCommaPHPOverride?: boolean,
+  singleQuoteOverride?: boolean,
 ): Promise<string | null> {
   const plugins = await resolvePhpPlugins(options);
   if (!plugins) return null;
 
-  const cacheKey = getPhpFormatCacheKey(snippet, mode, options, trailingCommaPHPOverride);
+  const cacheKey = getPhpFormatCacheKey(
+    snippet,
+    mode,
+    options,
+    trailingCommaPHPOverride,
+    singleQuoteOverride,
+  );
   if (phpFormatCache.has(cacheKey)) {
     return phpFormatCache.get(cacheKey) ?? null;
   }
@@ -539,7 +568,7 @@ async function formatPhpSnippet(
   try {
     const formatted = await prettierFormat(
       snippet,
-      createPhpFormatOptions(options, plugins, trailingCommaPHPOverride),
+      createPhpFormatOptions(options, plugins, trailingCommaPHPOverride, singleQuoteOverride),
     );
     const normalized = normalizeLineEndingsToLf(trimFinalLineBreak(formatted));
     setCachedPhpFormatResult(cacheKey, normalized);
@@ -884,7 +913,14 @@ export async function formatEchoNode(node: WrappedNode, options: Options): Promi
   const delegatedOptions = shouldCompensateInlineEchoPrintWidth(node)
     ? withCompensatedInlineEchoPrintWidth(wrapped, options)
     : options;
-  const formatted = await formatPhpSnippet(wrapped, delegatedOptions, mode);
+  const singleQuoteOverride = isInBladeComponentOpenTag(node, options) ? true : undefined;
+  const formatted = await formatPhpSnippet(
+    wrapped,
+    delegatedOptions,
+    mode,
+    undefined,
+    singleQuoteOverride,
+  );
   if (!formatted) return null;
 
   const extracted = getTextBetweenMarkers(formatted);

--- a/tests/options/component-open-tag-echo-quotes.test.ts
+++ b/tests/options/component-open-tag-echo-quotes.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import bladePlugin from "../../src/index.js";
+import * as phpPlugin from "@prettier/plugin-php";
+import { format } from "../helpers.js";
+
+const opts = {
+  plugins: [bladePlugin, phpPlugin],
+  bladePhpFormatting: "safe" as const,
+  singleQuote: false,
+};
+
+describe("options/component-open-tag-echo-quotes", () => {
+  it("forces single quotes inside echo in Blade component open tag", async () => {
+    const out = await format(
+      `<x-web.section {{ $attributes->class('min-h-dvh dark:bg-blue-grey-950') }}></x-web.section>\n`,
+      opts,
+    );
+    expect(out).toMatchInlineSnapshot(`
+      "<x-web.section
+        {{
+          $attributes->class(
+            'min-h-dvh dark:bg-blue-grey-950',
+          )
+        }}
+      ></x-web.section>
+      "
+    `);
+  });
+
+  it("applies to colon-namespaced component prefixes (livewire:, s:)", async () => {
+    const livewire = await format(
+      `<livewire:foo {{ $attributes->class('a b') }}></livewire:foo>\n`,
+      opts,
+    );
+    expect(livewire).toContain("'a b'");
+    expect(livewire).not.toContain('"a b"');
+
+    const sNs = await format(`<s:card {{ $attributes->class('a b') }}></s:card>\n`, opts);
+    expect(sNs).toContain("'a b'");
+    expect(sNs).not.toContain('"a b"');
+  });
+
+  it("applies to raw and triple echoes in component open tags", async () => {
+    const raw = await format(`<x-card {!! $attributes->class('a b') !!}></x-card>\n`, opts);
+    expect(raw).toContain("'a b'");
+    expect(raw).not.toContain('"a b"');
+
+    const triple = await format(`<x-card {{{ $attributes->class('a b') }}}></x-card>\n`, opts);
+    expect(triple).toContain("'a b'");
+    expect(triple).not.toContain('"a b"');
+  });
+
+  it("does not affect echoes in component body content", async () => {
+    const out = await format(`<x-card>{{ $foo->bar('baz') }}</x-card>\n`, opts);
+    // singleQuote: false → PHP formatter switches to double quotes inside body echoes.
+    expect(out).toContain('"baz"');
+  });
+
+  it("respects user singleQuote: true (no regression)", async () => {
+    const out = await format(`<x-card>{{ $foo->bar('baz') }}</x-card>\n`, {
+      ...opts,
+      singleQuote: true,
+    });
+    expect(out).toContain("'baz'");
+    expect(out).not.toContain('"baz"');
+  });
+});


### PR DESCRIPTION
Forces single quotes when formatting interpolations inside component  attribute contexts - fixes #153 