### PR TITLE
Expose Blade formatter ignore ranges

### DIFF
--- a/src/ignore-ranges.ts
+++ b/src/ignore-ranges.ts
@@ -1,0 +1,34 @@
+import type { Options } from "prettier";
+import { Directives as LexerDirectives } from "./lexer/directives.js";
+import { collectIgnoreRanges } from "./lexer/ignore-ranges.js";
+import type { IgnoreRangeRegion } from "./lexer/types.js";
+import { parseFrontMatter } from "./front-matter.js";
+import { resolveBladeSyntaxProfile } from "./plugins/runtime.js";
+
+export interface BladeIgnoreRange {
+  start: number;
+  end: number;
+}
+
+export function collectIgnoreRangeRegions(source: string, options?: unknown): IgnoreRangeRegion[] {
+  const hasBom = source.charCodeAt(0) === 0xfeff;
+  const { content } = parseFrontMatter(hasBom ? source.slice(1) : source);
+  // Front matter is blanked rather than sliced, so restoring the BOM keeps every offset raw.
+  const maskedSource = hasBom ? `\ufeff${content}` : content;
+  const syntaxProfile = resolveBladeSyntaxProfile(options);
+
+  return collectIgnoreRanges(maskedSource, LexerDirectives.acceptAll(), {
+    verbatimStartDirectives: syntaxProfile.verbatimStartDirectives,
+    verbatimEndDirectives: syntaxProfile.verbatimEndDirectives,
+  });
+}
+
+/**
+ * Return formatter ignore ranges as UTF-16 offsets into the unmodified source.
+ */
+export function getBladeIgnoreRanges(source: string, options?: Options): BladeIgnoreRange[] {
+  return collectIgnoreRangeRegions(source, options).map(({ start, end }) => ({
+    start,
+    end,
+  }));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -261,3 +261,4 @@ const plugin: Plugin = { languages, parsers, printers, options };
 
 export default plugin;
 export { languages, parsers, printers, options };
+export { getBladeIgnoreRanges, type BladeIgnoreRange } from "./ignore-ranges.js";

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,7 +1,5 @@
 import type { Parser } from "prettier";
 import { tokenize } from "./lexer/lexer.js";
-import { Directives as LexerDirectives } from "./lexer/directives.js";
-import { collectIgnoreRanges } from "./lexer/ignore-ranges.js";
 import { buildTree } from "./tree/tree-builder.js";
 import { Directives as TreeDirectives } from "./tree/directives.js";
 import type { WrappedNode } from "./types.js";
@@ -11,6 +9,7 @@ import { hasPragma } from "./pragma.js";
 import { resolveBladeSyntaxProfile } from "./plugins/runtime.js";
 import { markFrontMatter, parseFrontMatter, type FrontMatter } from "./front-matter.js";
 import { buildLineOffsets, getLine } from "./line-offsets.js";
+import { collectIgnoreRangeRegions } from "./ignore-ranges.js";
 
 const INTERNAL_KINDS = new Set([
   NodeKind.ElementName,
@@ -369,16 +368,11 @@ function parse(text: string, options?: unknown): WrappedNode {
   const { frontMatter, content } = parseFrontMatter(text);
 
   const syntaxProfile = resolveBladeSyntaxProfile(options);
-  const lexerDirectives = LexerDirectives.acceptAll();
   const parserOptions = (options ?? {}) as ParserOptionsWithIgnoreRanges;
   const ignoreRanges =
-    parserOptions[IGNORE_RANGES_OPTION] ??
-    collectIgnoreRanges(content, lexerDirectives, {
-      verbatimStartDirectives: syntaxProfile.verbatimStartDirectives,
-      verbatimEndDirectives: syntaxProfile.verbatimEndDirectives,
-    });
+    parserOptions[IGNORE_RANGES_OPTION] ?? collectIgnoreRangeRegions(text, options);
 
-  const { tokens } = tokenize(content, lexerDirectives, {
+  const { tokens } = tokenize(content, undefined, {
     verbatimStartDirectives: syntaxProfile.verbatimStartDirectives,
     verbatimEndDirectives: syntaxProfile.verbatimEndDirectives,
     ignoreRanges,
@@ -398,15 +392,9 @@ function parse(text: string, options?: unknown): WrappedNode {
 }
 
 function preprocess(text: string, options?: unknown): string {
-  const { content } = parseFrontMatter(text);
-  const syntaxProfile = resolveBladeSyntaxProfile(options);
-  const lexerDirectives = LexerDirectives.acceptAll();
   const parserOptions = (options ?? {}) as ParserOptionsWithIgnoreRanges;
 
-  parserOptions[IGNORE_RANGES_OPTION] = collectIgnoreRanges(content, lexerDirectives, {
-    verbatimStartDirectives: syntaxProfile.verbatimStartDirectives,
-    verbatimEndDirectives: syntaxProfile.verbatimEndDirectives,
-  });
+  parserOptions[IGNORE_RANGES_OPTION] = collectIgnoreRangeRegions(text, options);
 
   return text;
 }

--- a/tests/ignore-ranges.test.ts
+++ b/tests/ignore-ranges.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { getBladeIgnoreRanges } from "../src/index.js";
+
+describe("getBladeIgnoreRanges", () => {
+  it("returns offsets into the original source", () => {
+    const source =
+      '\uFEFF<div>\r\n  😀\r\n  {{-- format-ignore-start --}}\r\n  <span   class="x"></span>\r\n  {{-- format-ignore-end --}}\r\n</div>\r\n';
+
+    const ranges = getBladeIgnoreRanges(source);
+
+    expect(ranges).toHaveLength(1);
+    expect(source.slice(ranges[0].start, ranges[0].end)).toBe(
+      '{{-- format-ignore-start --}}\r\n  <span   class="x"></span>\r\n  {{-- format-ignore-end --}}',
+    );
+  });
+
+  it("uses configured verbatim directives when collecting ranges", () => {
+    const source = `---
+title: Example
+---
+@literal
+{{-- format-ignore-start --}}
+<span   class="x"></span>
+{{-- format-ignore-end --}}
+@endliteral
+`;
+
+    expect(getBladeIgnoreRanges(source)).toHaveLength(1);
+
+    const ranges = getBladeIgnoreRanges(source, {
+      bladeSyntaxPlugins: [
+        {
+          name: "test",
+          lexerDirectives: [],
+          treeDirectives: [],
+          verbatimStartDirectives: ["literal"],
+          verbatimEndDirectives: ["endliteral"],
+        },
+      ],
+    });
+
+    expect(ranges).toHaveLength(0);
+  });
+
+  it("ignores markers in BOM-prefixed front matter without shifting body ranges", () => {
+    for (const frontMatter of [
+      "title: {{-- format-ignore-start --}}\n{{-- format-ignore-end --}}",
+      "title: {{-- format-ignore-start --}}",
+    ]) {
+      const source = `\uFEFF---
+${frontMatter}
+---
+<div>before</div>
+{{-- format-ignore-start --}}
+<span   class="x"></span>
+{{-- format-ignore-end --}}
+`;
+
+      const ranges = getBladeIgnoreRanges(source);
+
+      expect(ranges).toHaveLength(1);
+      expect(source.slice(ranges[0].start, ranges[0].end)).toBe(
+        `{{-- format-ignore-start --}}
+<span   class="x"></span>
+{{-- format-ignore-end --}}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

This exposes a small `getBladeIgnoreRanges()` API around the ignore ranges already collected by the Blade lexer.

The returned values contain only `start` and `end` source offsets. Internal lexer resume state remains private, and the parser now shares the same collection helper so the public result follows the formatter's existing marker and syntax-plugin behavior.

The API is intended for [this draft Laravel Pint change](https://github.com/laravel/pint/pull/463), where Pint needs to protect ignored content from its own Blade pre- and post-formatters as well as from Prettier.

## Testing

- Full test suite: 5,781 passed
- TypeScript typecheck
- Lint and formatting checks
- Package build
